### PR TITLE
various fixes

### DIFF
--- a/.github/workflows/update-briefcase.yaml
+++ b/.github/workflows/update-briefcase.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Configure Git
         run: |

--- a/script/cli/src/libs/web3.rs
+++ b/script/cli/src/libs/web3.rs
@@ -1,4 +1,3 @@
-use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::FixedBytes;
 use alloy::providers::{Provider, ProviderBuilder, RootProvider};
 use alloy::transports::http::Http;

--- a/script/cli/src/screens/deploy_contracts/execute_deploy_script.rs
+++ b/script/cli/src/screens/deploy_contracts/execute_deploy_script.rs
@@ -124,6 +124,9 @@ impl ExecuteDeployScriptScreen {
                 }
             }
 
+            let _ =
+                std::fs::remove_file(get_config_dir(chain_id.clone()).join("task-pending.json"));
+
             let mut command = &mut Command::new("node");
             command = command
                 .arg(working_dir.join("lib").join("forge-chronicles"))
@@ -149,9 +152,6 @@ impl ExecuteDeployScriptScreen {
                     return;
                 }
             }
-
-            let _ =
-                std::fs::remove_file(get_config_dir(chain_id.clone()).join("task-pending.json"));
         });
 
         Ok(screen)


### PR DESCRIPTION
This pull request includes several changes aimed at improving the deployment script execution and updating dependencies. The most important changes include modifying the `execute_command` function to accept an optional private key, updating the Foundry toolchain version, and cleaning up temporary files after deployment.

Improvements to deployment script execution:

* [`script/cli/src/screens/deploy_contracts/execute_deploy_script.rs`](diffhunk://#diff-aec03d558fdd34c2b74cef8138a539b630658c8f71b6078cce3d23cea098efdbL77-R79): Modified the `execute_command` function to accept an optional private key and updated its usage accordingly. This change ensures that the private key is only passed when necessary. [[1]](diffhunk://#diff-aec03d558fdd34c2b74cef8138a539b630658c8f71b6078cce3d23cea098efdbL77-R79) [[2]](diffhunk://#diff-aec03d558fdd34c2b74cef8138a539b630658c8f71b6078cce3d23cea098efdbL114-R113) [[3]](diffhunk://#diff-aec03d558fdd34c2b74cef8138a539b630658c8f71b6078cce3d23cea098efdbL140-R142) [[4]](diffhunk://#diff-aec03d558fdd34c2b74cef8138a539b630658c8f71b6078cce3d23cea098efdbL172-R177)

Dependency updates:

* [`.github/workflows/update-briefcase.yaml`](diffhunk://#diff-bc39aaa02da2ea5ebfbdf980b05ea1d4bfffd1f205a7d4c10b86af5a3f6b903aL23-R23): Updated the Foundry toolchain version from `nightly` to `stable` to ensure more stable builds.

Code cleanup:

* [`script/cli/src/screens/deploy_contracts/execute_deploy_script.rs`](diffhunk://#diff-aec03d558fdd34c2b74cef8138a539b630658c8f71b6078cce3d23cea098efdbR127-R129): Added code to remove the `task-pending.json` file after deployment to clean up temporary files. [[1]](diffhunk://#diff-aec03d558fdd34c2b74cef8138a539b630658c8f71b6078cce3d23cea098efdbR127-R129) [[2]](diffhunk://#diff-aec03d558fdd34c2b74cef8138a539b630658c8f71b6078cce3d23cea098efdbL153-L155)

Unused imports removal:

* [`script/cli/src/libs/web3.rs`](diffhunk://#diff-da74962885c2659bc5db6b98bc6b52dde3b6e053898957e420504f9a0f1104e5L1): Removed the unused import `BlockNumberOrTag` to clean up the code.