### PR TITLE
use salted deploys for v4 and UR

### DIFF
--- a/script/deploy/Deploy-all.s.sol
+++ b/script/deploy/Deploy-all.s.sol
@@ -170,7 +170,9 @@ contract Deploy is Script {
             );
             address nftDescriptorImplementation =
                 address(NonfungibleTokenPositionDescriptorDeployer.deploy(weth(), nativeCurrencyLabelBytes));
-            nftDescriptor = address(new TransparentUpgradeableProxy(nftDescriptorImplementation, proxyAdminOwner, ''));
+            nftDescriptor = address(
+                new TransparentUpgradeableProxy{salt: hex'00'}(nftDescriptorImplementation, proxyAdminOwner, '')
+            );
         }
 
         if (deployNonfungiblePositionManager) {

--- a/src/briefcase/deployers/universal-router/UniversalRouterDeployer.sol
+++ b/src/briefcase/deployers/universal-router/UniversalRouterDeployer.sol
@@ -28,7 +28,7 @@ library UniversalRouterDeployer {
         });
         bytes memory initcode_ = abi.encodePacked(initcode(), abi.encode(params));
         assembly {
-            router := create(0, add(initcode_, 32), mload(initcode_))
+            router := create2(0, add(initcode_, 32), mload(initcode_), hex'00')
         }
     }
 

--- a/src/briefcase/deployers/v4-core/PoolManagerDeployer.sol
+++ b/src/briefcase/deployers/v4-core/PoolManagerDeployer.sol
@@ -9,7 +9,7 @@ library PoolManagerDeployer {
         bytes memory initcode_ = abi.encodePacked(initcode_override(), args);
 
         assembly {
-            manager := create(0, add(initcode_, 32), mload(initcode_))
+            manager := create2(0, add(initcode_, 32), mload(initcode_), hex'00')
         }
     }
 

--- a/src/briefcase/deployers/v4-periphery/PositionDescriptorDeployer.sol
+++ b/src/briefcase/deployers/v4-periphery/PositionDescriptorDeployer.sol
@@ -12,7 +12,7 @@ library PositionDescriptorDeployer {
         bytes memory initcode_ = abi.encodePacked(initcode(), args);
 
         assembly {
-            descriptor := create(0, add(initcode_, 32), mload(initcode_))
+            descriptor := create2(0, add(initcode_, 32), mload(initcode_), hex'00')
         }
     }
 

--- a/src/briefcase/deployers/v4-periphery/PositionManagerDeployer.sol
+++ b/src/briefcase/deployers/v4-periphery/PositionManagerDeployer.sol
@@ -15,7 +15,7 @@ library PositionManagerDeployer {
         bytes memory initcode_ = abi.encodePacked(initcode(), args);
 
         assembly {
-            manager := create(0, add(initcode_, 32), mload(initcode_))
+            manager := create2(0, add(initcode_, 32), mload(initcode_), hex'00')
         }
     }
 

--- a/src/briefcase/deployers/v4-periphery/StateViewDeployer.sol
+++ b/src/briefcase/deployers/v4-periphery/StateViewDeployer.sol
@@ -7,7 +7,7 @@ library StateViewDeployer {
         bytes memory initcode_ = abi.encodePacked(initcode(), args);
 
         assembly {
-            stateview := create(0, add(initcode_, 32), mload(initcode_))
+            stateview := create2(0, add(initcode_, 32), mload(initcode_), hex'00')
         }
     }
 

--- a/src/briefcase/deployers/v4-periphery/V4QuoterDeployer.sol
+++ b/src/briefcase/deployers/v4-periphery/V4QuoterDeployer.sol
@@ -9,7 +9,7 @@ library V4QuoterDeployer {
         bytes memory initcode_ = abi.encodePacked(initcode(), args);
 
         assembly {
-            v4quoter := create(0, add(initcode_, 32), mload(initcode_))
+            v4quoter := create2(0, add(initcode_, 32), mload(initcode_), hex'00')
         }
     }
 


### PR DESCRIPTION
This pull request includes several changes to the deployment scripts and libraries to use the `create2` opcode instead of `create`, which allows for deterministic contract deployment addresses. The most important changes are as follows:

Deployment script updates:

* [`script/deploy/Deploy-all.s.sol`](diffhunk://#diff-13aca0b46fb8d3737b71a7fa0366ac4ef3ae873c6ab349e64d426fd826b8f351L173-R175): Modified the deployment of `TransparentUpgradeableProxy` to use `create2` with a specified salt.

Library updates:

* [`src/briefcase/deployers/universal-router/UniversalRouterDeployer.sol`](diffhunk://#diff-2eac19e2677f2540e057c2404b6491e678bfd0260c2cf8538523ef7f3649205dL31-R31): Changed the deployment of the router to use `create2` with a specified salt.
* [`src/briefcase/deployers/v4-core/PoolManagerDeployer.sol`](diffhunk://#diff-7b5ac42ad313029396bd06c24ee6d33c475b1cb45001607ac9eebb9c9726d0e8L12-R12): Updated the deployment of the manager to use `create2` with a specified salt.
* [`src/briefcase/deployers/v4-periphery/PositionDescriptorDeployer.sol`](diffhunk://#diff-da8b4ca2cd3eae20e167990d586eb965b307d20061416d4d982bfe445dd7057aL15-R15): Modified the deployment of the descriptor to use `create2` with a specified salt.
* [`src/briefcase/deployers/v4-periphery/PositionManagerDeployer.sol`](diffhunk://#diff-15751efd1bb88170451d54bb41d620f15d32ee28a9cc69b29006d567df94afdbL18-R18): Updated the deployment of the manager to use `create2` with a specified salt.
* [`src/briefcase/deployers/v4-periphery/StateViewDeployer.sol`](diffhunk://#diff-bbbc1da95aa1b8585bc09cae1c7a65791f2d1acaf2308c3d507dabdc09d8881bL10-R10): Changed the deployment of the state view to use `create2` with a specified salt.
* [`src/briefcase/deployers/v4-periphery/V4QuoterDeployer.sol`](diffhunk://#diff-125d7e0a417cc832144645f718c180f43f63c1aa1b957c9ec1fb733edd253ebdL12-R12): Modified the deployment of the v4 quoter to use `create2` with a specified salt.