### PR TITLE
use salt with position descriptor transparent proxy

### DIFF
--- a/script/deploy/Deploy-all.s.sol
+++ b/script/deploy/Deploy-all.s.sol
@@ -170,9 +170,7 @@ contract Deploy is Script {
             );
             address nftDescriptorImplementation =
                 address(NonfungibleTokenPositionDescriptorDeployer.deploy(weth(), nativeCurrencyLabelBytes));
-            nftDescriptor = address(
-                new TransparentUpgradeableProxy{salt: hex'00'}(nftDescriptorImplementation, proxyAdminOwner, '')
-            );
+            nftDescriptor = address(new TransparentUpgradeableProxy(nftDescriptorImplementation, proxyAdminOwner, ''));
         }
 
         if (deployNonfungiblePositionManager) {
@@ -240,8 +238,9 @@ contract Deploy is Script {
             console.log('deploying Position Descriptor');
             address positionDescriptorImplementation =
                 address(PositionDescriptorDeployer.deploy(poolManager, weth(), nativeCurrencyLabelBytes));
-            positionDescriptor =
-                address(new TransparentUpgradeableProxy(positionDescriptorImplementation, proxyAdminOwner, ''));
+            positionDescriptor = address(
+                new TransparentUpgradeableProxy{salt: hex'00'}(positionDescriptorImplementation, proxyAdminOwner, '')
+            );
         }
 
         if (deployPositionManager) {


### PR DESCRIPTION
This pull request includes changes to the `Deploy` contract in the `script/deploy/Deploy-all.s.sol` file. The changes primarily involve modifying how the `TransparentUpgradeableProxy` is instantiated for the `nftDescriptor` and `positionDescriptor`.

Key changes:

* Simplified the instantiation of `TransparentUpgradeableProxy` for `nftDescriptor` by removing the `salt` parameter.
* Added the `salt` parameter during the instantiation of `TransparentUpgradeableProxy` for `positionDescriptor`.