### PR TITLE
split briefcase update into two steps

### DIFF
--- a/.github/workflows/push-briefcase.yaml
+++ b/.github/workflows/push-briefcase.yaml
@@ -1,0 +1,79 @@
+name: Push changes to Briefcase repo
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    # only push changes to briefcase repo if there are no changes to the deployers, if there are changes to the deployers a tenderly vnet is deployed first, after the deployment is complete this action will run again and push all changes to the briefcase repo
+    paths:
+      - deployments/**
+      - src/briefcase/**
+    paths-ignore:
+      - src/briefcase/deployers/**
+
+jobs:
+  update-briefcase:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Clone Briefcase Repository
+        run: |
+          git clone https://github.com/Uniswap/briefcase.git tmp_briefcase_repo
+
+      - name: Delete existing briefcase repo content
+        run: |
+          rm -rf tmp_briefcase_repo/src
+          rm -rf tmp_briefcase_repo/deployments
+          mkdir -p tmp_briefcase_repo/src
+          mkdir -p tmp_briefcase_repo/deployments
+
+      - name: Copy Briefcase
+        run: |
+          cp -r src/briefcase/* tmp_briefcase_repo/src
+          cp -r deployments/json/* tmp_briefcase_repo/deployments
+
+      - name: Check for Changes
+        id: git-check
+        run: |
+          cd tmp_briefcase_repo
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY_INTERFACES }}
+
+      - name: Commit and Push to briefcase repo if changes are present
+        if: steps.git-check.outputs.changes == 'true'
+        run: |
+          cd tmp_briefcase_repo
+          git remote set-url origin git@github.com:Uniswap/briefcase.git
+          git add .
+          git commit -m "Update briefcase
+
+          Changes:
+          $(git diff --cached --name-status)
+          "
+          git pull --rebase origin main
+          git push

--- a/.github/workflows/update-briefcase.yaml
+++ b/.github/workflows/update-briefcase.yaml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
     paths:
-      - deployments/**
       - src/pkgs/**
 
 jobs:
@@ -30,48 +29,19 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Clone Briefcase Repository
-        run: |
-          git clone https://github.com/Uniswap/briefcase.git tmp_briefcase_repo
-
-      - name: Delete existing briefcase repo content
-        run: |
-          rm -rf tmp_briefcase_repo/src
-          rm -rf tmp_briefcase_repo/deployments
-          mkdir -p tmp_briefcase_repo/src
-          mkdir -p tmp_briefcase_repo/deployments
-
       - name: Compile Briefcase
         run: |
           ./script/util/create_briefcase.sh
-          cp -r src/briefcase/* tmp_briefcase_repo/src
-          cp -r deployments/json/ tmp_briefcase_repo/deployments
-
-      - name: Check for Changes
-        id: git-check
-        run: |
-          cd tmp_briefcase_repo
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "changes=true" >> $GITHUB_OUTPUT
-          else
-            echo "changes=false" >> $GITHUB_OUTPUT
-          fi
 
       - name: Setup SSH
         uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387
         with:
-          ssh-private-key: ${{ secrets.DEPLOY_KEY_INTERFACES }}
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
-      - name: Commit and Push if Changes are Present
-        if: steps.git-check.outputs.changes == 'true'
+      - name: Commit and Push if changes are present
+        if: steps.git-check.outputs.changes != ''
         run: |
-          cd tmp_briefcase_repo
-          git remote set-url origin git@github.com:Uniswap/briefcase.git
+          git remote set-url origin git@github.com:${{ github.repository }}.git
           git add .
-          git commit -m "Update briefcase
-
-          Changes:
-          $(git diff --cached --name-status)
-          "
-          git pull --rebase origin main
+          git commit -m "Update briefcase"
           git push

--- a/.github/workflows/update-submodules.yaml
+++ b/.github/workflows/update-submodules.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
-      - name: Commit and Push if Changes are Present
+      - name: Commit and Push if changes are present
         if: steps.git-check.outputs.changes != ''
         run: |
           git remote set-url origin git@github.com:${{ github.repository }}.git


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflows to streamline the process of pushing changes to the Briefcase repository and updating submodules. The most important changes include the addition of a new workflow for pushing changes, modifications to existing workflows to improve efficiency, and adjustments to SSH setup and commit messages.

### New Workflow Addition:

* [`.github/workflows/push-briefcase.yaml`](diffhunk://#diff-58e94a455e0d98fafccbb3e3a89270824efa7f57ad1000507e6e8cd6771e1596R1-R79): Added a new workflow to push changes to the Briefcase repository, including steps for checking out the repository, installing Foundry, configuring Git, cloning the Briefcase repository, deleting existing content, copying new content, checking for changes, setting up SSH, and committing and pushing changes if present.

### Workflow Modifications:

* [`.github/workflows/update-briefcase.yaml`](diffhunk://#diff-bc39aaa02da2ea5ebfbdf980b05ea1d4bfffd1f205a7d4c10b86af5a3f6b903aL9): Removed paths related to deployments from the trigger conditions, and streamlined the job steps by removing the cloning and deletion of the Briefcase repository content. Adjusted the SSH key reference and simplified the commit and push steps. [[1]](diffhunk://#diff-bc39aaa02da2ea5ebfbdf980b05ea1d4bfffd1f205a7d4c10b86af5a3f6b903aL9) [[2]](diffhunk://#diff-bc39aaa02da2ea5ebfbdf980b05ea1d4bfffd1f205a7d4c10b86af5a3f6b903aL33-R46)

### SSH Setup and Commit Message Adjustments:

* [`.github/workflows/update-submodules.yaml`](diffhunk://#diff-aabb60a7f092054c236ba3ca3d107ee228c1ce3f03ac6be876eb8dfd226226deL43-R43): Updated the commit and push step to use a consistent condition for checking changes and adjusted the SSH key reference.