### PR TITLE
Fix compilation on latest foundry version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ This repo contains all Uniswap contracts. It is used to configure and execute de
 Follow these steps to set up your local environment:
 
 - [Install foundryup](https://book.getfoundry.sh/getting-started/installation)
-- Install foundry version `v0.3.0`: `foundryup --install v0.3.0`
-- Use foundry version `v0.3.0`: `foundryup --use v0.3.0`
 - Fetch submodules: `git submodule update --init --recursive`
 - Install dependencies: `forge install`
 - Build contracts: `forge build`

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,7 @@ libs = ["lib"]
 verbosity = 2
 bytecode_hash = "none"
 auto_detect_remappings = false
+optimizer = true
 
 fs_permissions = [
   { access = "read-write", path = ".forge-snapshots"},


### PR DESCRIPTION
Foundry 1.0.0 sets optimizer runs to false by default now. This PR fixes the compilation issues under the latest foundry version