### PR TITLE
Fix etherscan v2 verification after foundry update

### DIFF
--- a/script/cli/src/libs/explorer.rs
+++ b/script/cli/src/libs/explorer.rs
@@ -49,7 +49,7 @@ impl ExplorerApiLib {
                 return Ok(ExplorerApiLib {
                     explorer,
                     api_key: api_key.to_string(),
-                    api_url: format!("https://api.etherscan.io/v2/api?chainid={}", chain_id),
+                    api_url: format!("https://api.etherscan.io/v2/api"),
                 });
             } else {
                 return Err(format!(

--- a/script/cli/src/screens/verify_contract/verify_contract_screen.rs
+++ b/script/cli/src/screens/verify_contract/verify_contract_screen.rs
@@ -93,6 +93,8 @@ impl VerifyContractScreen {
                     "--verifier={}",
                     if explorer_api.explorer.explorer_type == SupportedExplorerType::Blockscout {
                         "blockscout"
+                    } else if explorer_api.explorer.explorer_type == SupportedExplorerType::EtherscanV2 {
+                        "etherscan"
                     } else {
                         // custom also works for etherscan
                         "custom"

--- a/script/cli/src/util/chain_config.rs
+++ b/script/cli/src/util/chain_config.rs
@@ -129,6 +129,7 @@ pub fn parse_chain_config() -> HashMap<String, Chain> {
                         let mut v2_explorer = etherscan_explorer.clone();
                         v2_explorer.explorer_type = SupportedExplorerType::EtherscanV2;
                         explorers.push(v2_explorer);
+                        explorers.retain(|e| e.explorer_type != SupportedExplorerType::Etherscan);
                         chains.get_mut(&chain_id).unwrap().explorers = explorers;
                     }
                 }


### PR DESCRIPTION
This pull request makes updates to support the new `EtherscanV2` explorer type and refines how explorers are handled within the application. The changes include modifying API URLs, adjusting explorer type logic, and ensuring appropriate filtering of explorer configurations.

### Updates to support `EtherscanV2` explorer type:

* [`script/cli/src/libs/explorer.rs`](diffhunk://#diff-84be0daea2732adbf2a708f4380e58b36da4ada76f548d910c94e47b71cf036dL52-R52): Updated the `api_url` initialization to remove the `chainid` parameter for `EtherscanV2`, simplifying the URL structure.
* [`script/cli/src/screens/verify_contract/verify_contract_screen.rs`](diffhunk://#diff-96535efd12a44e2fe1f0545eb13268a72630aef4cd84a6bc50bd763a50bc2b57R96-R97): Added logic to handle `EtherscanV2` in the `--verifier` argument, ensuring it is properly recognized and differentiated from other explorer types.

### Refinements to explorer configurations:

* [`script/cli/src/util/chain_config.rs`](diffhunk://#diff-934ccfdc5c94a6e0ac5c84d107a519c1eea660c78056c86077d06872352ff4a4R132): Ensured that the original `Etherscan` explorer type is filtered out when adding the new `EtherscanV2` explorer type, preventing duplication and maintaining clean configurations.