### PR TITLE
chore: verify chain 1 deployment logs

### DIFF
--- a/deployments/1.md
+++ b/deployments/1.md
@@ -7,13 +7,13 @@
 	- [E R C7914 Detector](#e-r-c7914-detector)
 	- [Wst E T H Hook](#wst-e-t-h-hook)
 	- [Wst E T H Routing Hook](#wst-e-t-h-routing-hook)
+	- [Calibur Entry](#calibur-entry)
 	- [W E T H Hook](#w-e-t-h-hook)
 	- [Mixed Route Quoter V2](#mixed-route-quoter-v2)
 	- [Position Descriptor](#position-descriptor)
 	- [Position Manager](#position-manager)
 	- [V4 Quoter](#v4-quoter)
 	- [State View](#state-view)
-	- [Universal Router](#universal-router)
 	- [Pool Manager](#pool-manager)
 	- [Fee On Transfer Detector](#fee-on-transfer-detector)
 	- [Fee Collector](#fee-collector)
@@ -34,7 +34,11 @@
 	- [Uniswap V3 Factory](#uniswap-v3-factory)
 	- [Uniswap V2 Router02](#uniswap-v2-router02)
 	- [Uniswap V2 Factory](#uniswap-v2-factory)
-	- [Calibur Entry](#calibur-entry)
+	- [Unsupported Protocol](#unsupported-protocol)
+	- [Uniswap Interface Multicall](#uniswap-interface-multicall)
+	- [Universal Router (v2.1)](#universal-router-v2.1)
+	- [Universal Router (v2.0)](#universal-router-v2.0)
+	- [Universal Router (v1.2)](#universal-router-v1.2)
 - [Deployment History](#deployment-history)
 	- [Thu Nov 20 2025](#thu-nov-20-2025)
 	- [Wed Aug 27 2025](#wed-aug-27-2025)
@@ -57,6 +61,8 @@
 	- [Tue May 04 2021](#tue-may-04-2021)
 	- [Fri Jun 05 2020](#fri-jun-05-2020)
 	- [Mon May 04 2020](#mon-may-04-2020)
+	- [Tue Jan 20 1970](#tue-jan-20-1970)
+	- [Mon Jan 19 1970](#mon-jan-19-1970)
 
 ## Summary
 <table>
@@ -77,6 +83,11 @@
 <tr>
     <td>WstETHRoutingHook</td>
     <td><a href="https://etherscan.io/address/0x3ac6e14a142251eb3fe739399e0a8da81ed06888" target="_blank">0x3ac6e14a142251eb3fe739399e0a8da81ed06888</a></td>
+    <td>N/A</td>
+    </tr>
+<tr>
+    <td>CaliburEntry</td>
+    <td><a href="https://etherscan.io/address/0x000000009b1d0af20d8c6d0a44e162d11f9b8f00" target="_blank">0x000000009b1d0af20d8c6d0a44e162d11f9b8f00</a></td>
     <td>N/A</td>
     </tr>
 <tr>
@@ -107,11 +118,6 @@
 <tr>
     <td>StateView</td>
     <td><a href="https://etherscan.io/address/0x7ffe42c4a5deea5b0fec41c94c136cf115597227" target="_blank">0x7ffe42c4a5deea5b0fec41c94c136cf115597227</a></td>
-    <td>N/A</td>
-    </tr>
-<tr>
-    <td>UniversalRouter</td>
-    <td><a href="https://etherscan.io/address/0xd92a36b0000531ef3063ded4de20a0783308446c" target="_blank">0xd92a36b0000531ef3063ded4de20a0783308446c</a></td>
     <td>N/A</td>
     </tr>
 <tr>
@@ -215,8 +221,28 @@
     <td>N/A</td>
     </tr>
 <tr>
-    <td>CaliburEntry</td>
-    <td><a href="https://etherscan.io/address/0x000000009b1d0af20d8c6d0a44e162d11f9b8f00" target="_blank">0x000000009b1d0af20d8c6d0a44e162d11f9b8f00</a></td>
+    <td>UnsupportedProtocol</td>
+    <td><a href="https://etherscan.io/address/0x76D631990d505E4e5b432EEDB852A60897824D68" target="_blank">0x76D631990d505E4e5b432EEDB852A60897824D68</a></td>
+    <td>N/A</td>
+    </tr>
+<tr>
+    <td>UniswapInterfaceMulticall</td>
+    <td><a href="https://etherscan.io/address/0x1F98415757620B543A52E61c46B32eB19261F984" target="_blank">0x1F98415757620B543A52E61c46B32eB19261F984</a></td>
+    <td>N/A</td>
+    </tr>
+<tr>
+    <td>UniversalRouter#v2.1</td>
+    <td><a href="https://etherscan.io/address/0xd92a36b0000531ef3063ded4de20a0783308446c" target="_blank">0xd92a36b0000531ef3063ded4de20a0783308446c</a></td>
+    <td>N/A</td>
+    </tr>
+<tr>
+    <td>UniversalRouter#v2.0</td>
+    <td><a href="https://etherscan.io/address/0x66a9893cc07d91d95644aedd05d03f95e1dba8af" target="_blank">0x66a9893cc07d91d95644aedd05d03f95e1dba8af</a></td>
+    <td>N/A</td>
+    </tr>
+<tr>
+    <td>UniversalRouter#v1.2</td>
+    <td><a href="https://etherscan.io/address/0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD" target="_blank">0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD</a></td>
     <td>N/A</td>
     </tr></table>
 
@@ -265,6 +291,22 @@ Deployment Transaction: [0xbe0998cacc36d9689aaa6ada9975df5bf480b486cdd568a50b814
 Commit Hash: [320811c](https://github.com/Uniswap/contracts/commit/320811c)
 
 Wed, 27 Aug 2025 20:25:51 UTC
+
+
+
+---
+
+### Calibur Entry
+
+Address: [0x000000009b1d0af20d8c6d0a44e162d11f9b8f00](https://etherscan.io/address/0x000000009b1d0af20d8c6d0a44e162d11f9b8f00)
+
+Deployment Transaction: [0xf7d094c82512c971d821190e914eada76eec34da638736f09fa2fe1a9456d894](https://etherscan.io/tx/0xf7d094c82512c971d821190e914eada76eec34da638736f09fa2fe1a9456d894)
+
+
+
+Commit Hash: [0a52cd5](https://github.com/Uniswap/contracts/commit/0a52cd5)
+
+Fri, 23 May 2025 19:33:25 UTC
 
 
 
@@ -390,22 +432,6 @@ Deployment Transaction: [0x3d71d82b2c02425520a1296de1513ab45c4fc6e4768582673ae68
 Commit Hash: [2656054](https://github.com/Uniswap/contracts/commit/2656054)
 
 Thu, 23 Jan 2025 18:52:35 UTC
-
-
-
----
-
-### Universal Router
-
-Address: [0xd92a36b0000531ef3063ded4de20a0783308446c](https://etherscan.io/address/0xd92a36b0000531ef3063ded4de20a0783308446c)
-
-Deployment Transaction: [0xc4c3e553b5a5067baf9504257279483ec4e5e08268010d3ec4e3f256e2f7cd1e](https://etherscan.io/tx/0xc4c3e553b5a5067baf9504257279483ec4e5e08268010d3ec4e3f256e2f7cd1e)
-
-
-
-Commit Hash: [d2d9c4a](https://github.com/Uniswap/contracts/commit/d2d9c4a)
-
-Wed, 19 Nov 2025 23:20:49 UTC
 
 
 
@@ -764,17 +790,81 @@ Mon, 04 May 2020 16:34:02 UTC
 
 ---
 
-### Calibur Entry
+### Unsupported Protocol
 
-Address: [0x000000009b1d0af20d8c6d0a44e162d11f9b8f00](https://etherscan.io/address/0x000000009b1d0af20d8c6d0a44e162d11f9b8f00)
+Address: [0x76D631990d505E4e5b432EEDB852A60897824D68](https://etherscan.io/address/0x76D631990d505E4e5b432EEDB852A60897824D68)
 
-Deployment Transaction: [0xf7d094c82512c971d821190e914eada76eec34da638736f09fa2fe1a9456d894](https://etherscan.io/tx/0xf7d094c82512c971d821190e914eada76eec34da638736f09fa2fe1a9456d894)
+Deployment Transaction: [0xb31dae32cbd0c8160debc469ce67a71fa530083b3630846fa01355a76bff249e](https://etherscan.io/tx/0xb31dae32cbd0c8160debc469ce67a71fa530083b3630846fa01355a76bff249e)
 
 
 
-Commit Hash: [0a52cd5](https://github.com/Uniswap/contracts/commit/0a52cd5)
 
-Fri, 23 May 2025 19:33:25 UTC
+
+Tue, 20 Jan 1970 07:48:42 UTC
+
+
+
+---
+
+### Uniswap Interface Multicall
+
+Address: [0x1F98415757620B543A52E61c46B32eB19261F984](https://etherscan.io/address/0x1F98415757620B543A52E61c46B32eB19261F984)
+
+Deployment Transaction: [0x260f9c7ebc1cc203a13422206d8c9532ce11fd9d5523caa9cb4b58f7193cf7cc](https://etherscan.io/tx/0x260f9c7ebc1cc203a13422206d8c9532ce11fd9d5523caa9cb4b58f7193cf7cc)
+
+
+
+
+
+Mon, 19 Jan 1970 19:27:25 UTC
+
+
+
+---
+
+### Universal Router (v2.1)
+
+Address: [0xd92a36b0000531ef3063ded4de20a0783308446c](https://etherscan.io/address/0xd92a36b0000531ef3063ded4de20a0783308446c)
+
+Deployment Transaction: [0xc4c3e553b5a5067baf9504257279483ec4e5e08268010d3ec4e3f256e2f7cd1e](https://etherscan.io/tx/0xc4c3e553b5a5067baf9504257279483ec4e5e08268010d3ec4e3f256e2f7cd1e)
+
+
+
+Commit Hash: [d2d9c4a](https://github.com/Uniswap/contracts/commit/d2d9c4a)
+
+Wed, 19 Nov 2025 23:20:49 UTC
+
+
+
+---
+
+### Universal Router (v2.0)
+
+Address: [0x66a9893cc07d91d95644aedd05d03f95e1dba8af](https://etherscan.io/address/0x66a9893cc07d91d95644aedd05d03f95e1dba8af)
+
+Deployment Transaction: [0x7e770b7713bde88afd49651461b8533a5e7d864b9ddb20252392aaa1ef6cc6e0](https://etherscan.io/tx/0x7e770b7713bde88afd49651461b8533a5e7d864b9ddb20252392aaa1ef6cc6e0)
+
+
+
+Commit Hash: [2656054](https://github.com/Uniswap/contracts/commit/2656054)
+
+Thu, 23 Jan 2025 18:52:35 UTC
+
+
+
+---
+
+### Universal Router (v1.2)
+
+Address: [0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD](https://etherscan.io/address/0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD)
+
+Deployment Transaction: [0x8262d7c12366abc7282b0bc5ad2e7376309eb72f07af6fa0ab1c82ad3d13555b](https://etherscan.io/tx/0x8262d7c12366abc7282b0bc5ad2e7376309eb72f07af6fa0ab1c82ad3d13555b)
+
+
+
+
+
+Fri, 28 Apr 2023 09:45:11 UTC
 
 
 
@@ -789,7 +879,7 @@ Deployed contracts:
 
 <details>
   <summary>
-    <a href="https://etherscan.io/address/0xd92a36b0000531ef3063ded4de20a0783308446c">Universal Router</a>
+    <a href="https://etherscan.io/address/0xd92a36b0000531ef3063ded4de20a0783308446c">Universal Router (v2.1)</a>
   </summary>
   <table>
     <tr>
@@ -1106,7 +1196,7 @@ Deployed contracts:
 </details>
 <details>
   <summary>
-    <a href="https://etherscan.io/address/0x66a9893cc07d91d95644aedd05d03f95e1dba8af">Universal Router</a>
+    <a href="https://etherscan.io/address/0x66a9893cc07d91d95644aedd05d03f95e1dba8af">Universal Router (v2.0)</a>
   </summary>
   <table>
     <tr>
@@ -1327,7 +1417,7 @@ Deployed contracts:
 
 <details>
   <summary>
-    <a href="https://etherscan.io/address/0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD">Universal Router</a>
+    <a href="https://etherscan.io/address/0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD">Universal Router (v1.2)</a>
   </summary>
   <table>
     
@@ -1352,7 +1442,7 @@ Deployed contracts:
 
 <details>
   <summary>
-    <a href="https://etherscan.io/address/0xEf1c6E67703c7BD7107eed8303Fbe6EC2554BF6B">Universal Router</a>
+    <a href="https://etherscan.io/address/0xEf1c6E67703c7BD7107eed8303Fbe6EC2554BF6B">Universal Router (v1.2)</a>
   </summary>
   <table>
     
@@ -1671,6 +1761,40 @@ Deployed contracts:
       <td>_feeToSetter</td>
       <td><a href="https://etherscan.io/address/0xc0a4272bb5df52134178Df25d77561CfB17ce407" target="_blank">0xc0a4272bb5df52134178Df25d77561CfB17ce407</a></td>
     </tr>
+  </table>
+</details>
+  
+
+
+### Tue Jan 20 1970
+
+  
+
+Deployed contracts:
+
+<details>
+  <summary>
+    <a href="https://etherscan.io/address/0x76D631990d505E4e5b432EEDB852A60897824D68">Unsupported Protocol</a>
+  </summary>
+  <table>
+    
+  </table>
+</details>
+  
+
+
+### Mon Jan 19 1970
+
+  
+
+Deployed contracts:
+
+<details>
+  <summary>
+    <a href="https://etherscan.io/address/0x1F98415757620B543A52E61c46B32eB19261F984">Uniswap Interface Multicall</a>
+  </summary>
+  <table>
+    
   </table>
 </details>
   

--- a/deployments/json/1.json
+++ b/deployments/json/1.json
@@ -22,6 +22,13 @@
       "timestamp": 1756326351000,
       "commitHash": "320811c"
     },
+    "CaliburEntry": {
+      "address": "0x000000009b1d0af20d8c6d0a44e162d11f9b8f00",
+      "proxy": false,
+      "deploymentTxn": "0xf7d094c82512c971d821190e914eada76eec34da638736f09fa2fe1a9456d894",
+      "timestamp": 1748028805000,
+      "commitHash": "0a52cd5"
+    },
     "WETHHook": {
       "address": "0x57991106cb7aa27e2771beda0d6522f68524a888",
       "proxy": false,
@@ -65,13 +72,6 @@
       "deploymentTxn": "0x3d71d82b2c02425520a1296de1513ab45c4fc6e4768582673ae68aff4bb1b3f0",
       "timestamp": 1737658355000,
       "commitHash": "2656054"
-    },
-    "UniversalRouter": {
-      "address": "0xd92a36b0000531ef3063ded4de20a0783308446c",
-      "proxy": false,
-      "deploymentTxn": "0xc4c3e553b5a5067baf9504257279483ec4e5e08268010d3ec4e3f256e2f7cd1e",
-      "timestamp": 1763594449915,
-      "commitHash": "d2d9c4a"
     },
     "PoolManager": {
       "address": "0x000000000004444c5dc75cB358380D2e3dE08A90",
@@ -196,18 +196,43 @@
       "deploymentTxn": "0xc31d7e7e85cab1d38ce1b8ac17e821ccd47dbde00f9d57f2bd8613bff9428396",
       "timestamp": 1588610042000
     },
-    "CaliburEntry": {
-      "address": "0x000000009b1d0af20d8c6d0a44e162d11f9b8f00",
+    "UnsupportedProtocol": {
+      "address": "0x76D631990d505E4e5b432EEDB852A60897824D68",
       "proxy": false,
-      "deploymentTxn": "0xf7d094c82512c971d821190e914eada76eec34da638736f09fa2fe1a9456d894",
-      "timestamp": 1748028805000,
-      "commitHash": "0a52cd5"
+      "deploymentTxn": "0xb31dae32cbd0c8160debc469ce67a71fa530083b3630846fa01355a76bff249e",
+      "timestamp": 1669722683
+    },
+    "UniswapInterfaceMulticall": {
+      "address": "0x1F98415757620B543A52E61c46B32eB19261F984",
+      "proxy": false,
+      "deploymentTxn": "0x260f9c7ebc1cc203a13422206d8c9532ce11fd9d5523caa9cb4b58f7193cf7cc",
+      "timestamp": 1625245552
+    },
+    "UniversalRouter#v2.1": {
+      "address": "0xd92a36b0000531ef3063ded4de20a0783308446c",
+      "proxy": false,
+      "deploymentTxn": "0xc4c3e553b5a5067baf9504257279483ec4e5e08268010d3ec4e3f256e2f7cd1e",
+      "timestamp": 1763594449915,
+      "commitHash": "d2d9c4a"
+    },
+    "UniversalRouter#v2.0": {
+      "address": "0x66a9893cc07d91d95644aedd05d03f95e1dba8af",
+      "proxy": false,
+      "deploymentTxn": "0x7e770b7713bde88afd49651461b8533a5e7d864b9ddb20252392aaa1ef6cc6e0",
+      "timestamp": 1737658355000,
+      "commitHash": "2656054"
+    },
+    "UniversalRouter#v1.2": {
+      "address": "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD",
+      "proxy": false,
+      "deploymentTxn": "0x8262d7c12366abc7282b0bc5ad2e7376309eb72f07af6fa0ab1c82ad3d13555b",
+      "timestamp": 1682675111000
     }
   },
   "history": [
     {
       "contracts": {
-        "UniversalRouter": {
+        "UniversalRouter#v2.1": {
           "address": "0xd92a36b0000531ef3063ded4de20a0783308446c",
           "proxy": false,
           "deploymentTxn": "0xc4c3e553b5a5067baf9504257279483ec4e5e08268010d3ec4e3f256e2f7cd1e",
@@ -396,7 +421,7 @@
             }
           }
         },
-        "UniversalRouter": {
+        "UniversalRouter#v2.0": {
           "address": "0x66a9893cc07d91d95644aedd05d03f95e1dba8af",
           "proxy": false,
           "deploymentTxn": "0x7e770b7713bde88afd49651461b8533a5e7d864b9ddb20252392aaa1ef6cc6e0",
@@ -545,7 +570,7 @@
     },
     {
       "contracts": {
-        "UniversalRouter": {
+        "UniversalRouter#v1.2": {
           "address": "0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD",
           "proxy": false,
           "deploymentTxn": "0x8262d7c12366abc7282b0bc5ad2e7376309eb72f07af6fa0ab1c82ad3d13555b",
@@ -581,7 +606,7 @@
     },
     {
       "contracts": {
-        "UniversalRouter": {
+        "UniversalRouter#v1.2": {
           "address": "0xEf1c6E67703c7BD7107eed8303Fbe6EC2554BF6B",
           "proxy": false,
           "deploymentTxn": "0x045ea812f7e8b5faa6f1146dbfc66beb37677f2c4e40f2f7659f70bb914035db",
@@ -834,6 +859,32 @@
         }
       },
       "timestamp": 1588610042000
+    },
+    {
+      "contracts": {
+        "UnsupportedProtocol": {
+          "address": "0x76D631990d505E4e5b432EEDB852A60897824D68",
+          "proxy": false,
+          "deploymentTxn": "0xb31dae32cbd0c8160debc469ce67a71fa530083b3630846fa01355a76bff249e",
+          "input": {
+            "constructor": {}
+          }
+        }
+      },
+      "timestamp": 1669722683
+    },
+    {
+      "contracts": {
+        "UniswapInterfaceMulticall": {
+          "address": "0x1F98415757620B543A52E61c46B32eB19261F984",
+          "proxy": false,
+          "deploymentTxn": "0x260f9c7ebc1cc203a13422206d8c9532ce11fd9d5523caa9cb4b58f7193cf7cc",
+          "input": {
+            "constructor": {}
+          }
+        }
+      },
+      "timestamp": 1625245552
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Added missing `UniswapInterfaceMulticall` and `UnsupportedProtocol` contracts
- Tagged UniversalRouter versions (`#v2.1`, `#v2.0`, `#v1.2`) in both `latest` and `history`
- Verified `ERC7914Detector` on Etherscan (was the only unverified contract)
- Regenerated deployment markdown

## Notes
- `PriorityOrderReactor` is not deployed on mainnet (only on L2s with priority gas auctions)
- All 35 contracts are now verified on Etherscan