### PR TITLE
Record adopted Protofire periphery on Ink (57073): V2Router02, V3Migrator, V3Staker

### DIFF
--- a/deployments/57073.md
+++ b/deployments/57073.md
@@ -20,6 +20,7 @@
 	- [E R C7914 Detector](#e-r-c7914-detector)
 	- [Swap Proxy](#swap-proxy)
 	- [Uniswap V2 Factory](#uniswap-v2-factory)
+	- [Uniswap V2 Router02](#uniswap-v2-router02)
 	- [Uniswap V3 Factory](#uniswap-v3-factory)
 	- [Uniswap Interface Multicall](#uniswap-interface-multicall)
 	- [Quoter V2](#quoter-v2)
@@ -27,6 +28,8 @@
 	- [N F T Descriptor](#n-f-t-descriptor)
 	- [Nonfungible Position Manager](#nonfungible-position-manager)
 	- [Swap Router02](#swap-router02)
+	- [V3 Migrator](#v3-migrator)
+	- [Uniswap V3 Staker](#uniswap-v3-staker)
 	- [Nonfungible Token Position Descriptor](#nonfungible-token-position-descriptor)
 	- [Permit2](#permit2)
 - [Deployment History](#deployment-history)
@@ -119,6 +122,11 @@
     <td>N/A</td>
     </tr>
 <tr>
+    <td>UniswapV2Router02</td>
+    <td>0xb3fb126acdd5adca2f50ac644a7a2303745f18b4</td>
+    <td>N/A</td>
+    </tr>
+<tr>
     <td>UniswapV3Factory</td>
     <td>0x640887A9ba3A9C53Ed27D0F7e8246A4F933f3424</td>
     <td>N/A</td>
@@ -151,6 +159,16 @@
 <tr>
     <td>SwapRouter02</td>
     <td>0x177778F19E89dD1012BdBe603F144088A95C4B53</td>
+    <td>N/A</td>
+    </tr>
+<tr>
+    <td>V3Migrator</td>
+    <td>0xdce28d2d5392e19091fe59d9750b3202ebe80641</td>
+    <td>N/A</td>
+    </tr>
+<tr>
+    <td>UniswapV3Staker</td>
+    <td>0x245c0c29bb7dd9d1fa6a0713abfeb81439ffa870</td>
     <td>N/A</td>
     </tr>
 <tr>
@@ -451,6 +469,22 @@ Thu, 12 Dec 2024 17:02:02 UTC
 
 ---
 
+### Uniswap V2 Router02
+
+Address: 0xb3fb126acdd5adca2f50ac644a7a2303745f18b4
+
+Deployment Transaction: 0xe56fc5d5808e1488364346ff250255edc21711e98ee1eb9aaeefd3432d638e42
+
+
+
+
+
+Thu, 12 Dec 2024 17:02:28 UTC
+
+
+
+---
+
 ### Uniswap V3 Factory
 
 Address: 0x640887A9ba3A9C53Ed27D0F7e8246A4F933f3424
@@ -558,6 +592,38 @@ Deployment Transaction: 0xd12637ba2798952d50ba256403c7a15d4dbb69d92afaa71f6a0a4c
 
 
 Mon, 09 Dec 2024 22:16:43 UTC
+
+
+
+---
+
+### V3 Migrator
+
+Address: 0xdce28d2d5392e19091fe59d9750b3202ebe80641
+
+Deployment Transaction: 0x342077a8450084d79ae3345d8bce0f83e246af5b4babbf86b1e178b75090c021
+
+
+
+
+
+Mon, 09 Dec 2024 22:16:25 UTC
+
+
+
+---
+
+### Uniswap V3 Staker
+
+Address: 0x245c0c29bb7dd9d1fa6a0713abfeb81439ffa870
+
+Deployment Transaction: 0x9da25176b5dcb78fe7d8ac9ad3933802f3399be030c96b49711d9443817d9a94
+
+
+
+
+
+Mon, 09 Dec 2024 22:16:31 UTC
 
 
 

--- a/deployments/json/57073.json
+++ b/deployments/json/57073.json
@@ -115,6 +115,13 @@
       "timestamp": 1734022922000,
       "note": "Protofire deploy (Dec 2024, v3-on-Ink governance RFC); adopted, not deployed by this repo"
     },
+    "UniswapV2Router02": {
+      "address": "0xb3fb126acdd5adca2f50ac644a7a2303745f18b4",
+      "proxy": false,
+      "deploymentTxn": "0xe56fc5d5808e1488364346ff250255edc21711e98ee1eb9aaeefd3432d638e42",
+      "timestamp": 1734022948000,
+      "note": "Protofire deploy (Dec 2024, v3-on-Ink governance RFC); adopted, not deployed by this repo"
+    },
     "UniswapV3Factory": {
       "address": "0x640887A9ba3A9C53Ed27D0F7e8246A4F933f3424",
       "proxy": false,
@@ -162,6 +169,20 @@
       "proxy": false,
       "deploymentTxn": "0xd12637ba2798952d50ba256403c7a15d4dbb69d92afaa71f6a0a4cfa2fc22849",
       "timestamp": 1733782603000,
+      "note": "Protofire deploy (Dec 2024, v3-on-Ink governance RFC); adopted, not deployed by this repo"
+    },
+    "V3Migrator": {
+      "address": "0xdce28d2d5392e19091fe59d9750b3202ebe80641",
+      "proxy": false,
+      "deploymentTxn": "0x342077a8450084d79ae3345d8bce0f83e246af5b4babbf86b1e178b75090c021",
+      "timestamp": 1733782585000,
+      "note": "Protofire deploy (Dec 2024, v3-on-Ink governance RFC); adopted, not deployed by this repo"
+    },
+    "UniswapV3Staker": {
+      "address": "0x245c0c29bb7dd9d1fa6a0713abfeb81439ffa870",
+      "proxy": false,
+      "deploymentTxn": "0x9da25176b5dcb78fe7d8ac9ad3933802f3399be030c96b49711d9443817d9a94",
+      "timestamp": 1733782591000,
       "note": "Protofire deploy (Dec 2024, v3-on-Ink governance RFC); adopted, not deployed by this repo"
     },
     "NonfungibleTokenPositionDescriptor": {


### PR DESCRIPTION
## What

Backfills three contracts into the Ink (57073) deployment registry that were **deployed and Blockscout-verified by Protofire** in the original Ink deploy (Dec 2024) but were never recorded in `deployments/57073.md` / `deployments/json/57073.json`:

| Contract | Address | Role |
|---|---|---|
| `UniswapV2Router02` | `0xb3fb126acdd5adca2f50ac644a7a2303745f18b4` | v2 swaps + LP add/remove |
| `V3Migrator` | `0xdce28d2d5392e19091fe59d9750b3202ebe80641` | migrate v2 LP → v3 |
| `UniswapV3Staker` | `0x245c0c29bb7dd9d1fa6a0713abfeb81439ffa870` | v3 liquidity mining |

## Why

A teammate asked whether Ink was missing `UniswapV2Router02` (the v2 LP-management router, a default on every full-stack chain). It isn't missing on-chain — Protofire deployed it — it was just missing from our registry. Reconciling Protofire's full contract-creation history surfaced two more deployed-but-unrecorded contracts (`V3Migrator`, `UniswapV3Staker`), so this records all three.

## Verification

All three are live and verified on `explorer.inkonchain.com`. `UniswapV2Router02` fingerprint confirmed: `factory()` → Ink v2 Factory `0xfe57…0C04`, `WETH()` → Ink WETH `0x4200…0006`, solc 0.6.6 (canonical v2-periphery), working `quote`/`getAmountOut`.

## Notes

- **Registry-only change. No on-chain action.**
- Recorded with the same adopted-contract schema already used for the other Protofire v2/v3 entries (`note` field, no `commitHash`).
- Deployment txns and timestamps taken from the contracts' creation transactions on Ink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)