### PR TITLE
feat: record Sepolia UniversalRouter 2.1.1 deployment

### DIFF
--- a/deployments/11155111.md
+++ b/deployments/11155111.md
@@ -55,6 +55,11 @@
     <td>N/A</td>
     </tr>
 <tr>
+    <td>UniversalRouter#v2.1.1</td>
+    <td><a href="https://sepolia.etherscan.io/address/0x7DfD4F31be6814D2906BDE155c3e1B146EAc1468" target="_blank">0x7DfD4F31be6814D2906BDE155c3e1B146EAc1468</a></td>
+    <td>N/A</td>
+    </tr>
+<tr>
     <td>CaliburEntry</td>
     <td><a href="https://sepolia.etherscan.io/address/0x000000009b1d0af20d8c6d0a44e162d11f9b8f00" target="_blank">0x000000009b1d0af20d8c6d0a44e162d11f9b8f00</a></td>
     <td>N/A</td>

--- a/deployments/json/11155111.json
+++ b/deployments/json/11155111.json
@@ -149,9 +149,45 @@
       "deploymentTxn": "0x26088229e4483048190c07c0de4506668fc01bea726a91203f61d7e95663fb69",
       "timestamp": 1783981680000,
       "commitHash": "b08eb66"
+    },
+    "UniversalRouter#v2.1.1": {
+      "address": "0x7DfD4F31be6814D2906BDE155c3e1B146EAc1468",
+      "proxy": false,
+      "deploymentTxn": "0xc1ebad5554a50e1fa55274b40ef17dc899bef7378b88b8cfe2fcdebc89a014b6",
+      "initcodeHash": "52f2a40a9da3a1f22d38ae2520d35ded61353f95b7df765e558e30d3ff9ea809",
+      "timestamp": 1784925506763,
+      "commitHash": "999d561"
     }
   },
   "history": [
+    {
+      "contracts": {
+        "UniversalRouter#v2.1.1": {
+          "address": "0x7DfD4F31be6814D2906BDE155c3e1B146EAc1468",
+          "proxy": false,
+          "deploymentTxn": "0xc1ebad5554a50e1fa55274b40ef17dc899bef7378b88b8cfe2fcdebc89a014b6",
+          "initcodeHash": "52f2a40a9da3a1f22d38ae2520d35ded61353f95b7df765e558e30d3ff9ea809",
+          "input": {
+            "constructor": {
+              "params": {
+                "permit2": "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+                "weth9": "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14",
+                "v2Factory": "0xB7f907f7A9eBC822a80BD25E224be42Ce0A698A0",
+                "v3Factory": "0x0227628f3F023bb0B980b67D528571c95c6DaC1c",
+                "pairInitCodeHash": "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f",
+                "poolInitCodeHash": "0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54",
+                "v4PoolManager": "0xE03A1074c86CFeDd5C142C4F04F1a1536e203543",
+                "v3NFTPositionManager": "0x1238536071E1c677A632429e3655c799b22cDA52",
+                "v4PositionManager": "0x429ba70129df741B2Ca2a85BC3A2a3328e5c09b4",
+                "spokePool": "0x5ef6C01E11889d86803e0B23e3cB3F9E9d97B662"
+              }
+            }
+          }
+        }
+      },
+      "timestamp": 1784925506763,
+      "commitHash": "999d561"
+    },
     {
       "contracts": {
         "PermissionedHooks#07cdcd92": {


### PR DESCRIPTION
## What

Adds `UniversalRouter#v2.1.1` at `0x7DfD4F31be6814D2906BDE155c3e1B146EAc1468` to the Sepolia (11155111) registry (latest + history + summary table).

## Context

Deployed 2026-07-24 from the universal-router `2.1.1` tag (commit `999d561`) with corrected params: PoolManager `0xE03A1074c86CFeDd5C142C4F04F1a1536e203543`, v4 PositionManager `0x429ba70129df741B2Ca2a85BC3A2a3328e5c09b4`, canonical v2 factory `0xB7f907f7A9eBC822a80BD25E224be42Ce0A698A0`. The stock 2.1.1-tag params ship the old PoolManager and a stale posm, which produced two earlier misconfigured Sepolia routers (`0x8B84...1E6b`, `0xEd48...BaBC`) that should not be used.

Tx `0xc1ebad5554a50e1fa55274b40ef17dc899bef7378b88b8cfe2fcdebc89a014b6`, verified on Sourcify; immutables confirmed in deployed bytecode.

Related: Uniswap/universal-router#495, Uniswap/universal-router#496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)