### PR TITLE
feat(deployments): MixedRouteQuoterV2 on Robinhood (4663)

### DIFF
--- a/deployments/json/4663.json
+++ b/deployments/json/4663.json
@@ -191,6 +191,14 @@
       "deploymentTxn": "0x1c50a8395b386d7d1a81346e6dcf8f0d1a1b4c4bae7f54796f701367d241df0f",
       "timestamp": 1783983371000,
       "commitHash": "b08eb66"
+    },
+    "MixedRouteQuoterV2": {
+      "address": "0x7edd862aa08dd5be664c21188e1a2a0e64e3a283",
+      "proxy": false,
+      "deploymentTxn": "0xf67f1663ddbb7dec8d0792a4571bf024bc6521a4fcf12e574342623c856c6075",
+      "initcodeHash": "50a98843e464b35961e16dbbda55b730381f38a1dea5aa222ae5955b52b7a67e",
+      "timestamp": 1785791720000,
+      "commitHash": "0ecb1fc"
     }
   },
   "history": [


### PR DESCRIPTION
Backfills MixedRouteQuoterV2 on Robinhood chain (4663), it was missing from RH's deployment set (spotted by @Cody).

- **Address:** `0x7edd862aa08dd5be664c21188e1a2a0e64e3a283` ([Blockscout](https://8crv4vmq6tiu1yqr.blockscout.com/address/0x7edd862aa08dD5Be664C21188E1A2A0E64e3A283), verified)
- **Deploy tx:** `0xf67f1663ddbb7dec8d0792a4571bf024bc6521a4fcf12e574342623c856c6075`
- **Constructor** `(poolManager, v3Factory, v2Factory)` wired to the existing RH cores, each confirmed on-chain before deploy (v2Factory's feeToSetter is the aliased L1 timelock, v3Factory owner responds, PoolManager has code). On-chain `poolManager()` / `uniswapV3Poolfactory()` read back the passed values.

Deployed via standalone `forge create` (freshly-compiled bytecode, mixed-quoter profile: 0.8.26 / via-ir / 200 / cancun) rather than `Deploy-all.s.sol`, since the script path needs a fully-wired task file. Registry entry only; no source changes.

Follow-up (separate): add MixedRouteQuoterV2 to the standard new-chain task template so future chains get it by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)