### PR TITLE
fix(smoke): prefer UniversalRouter#v2.2 in v4 smoke tests

### DIFF
--- a/script/smoke/V4SmokeTest.s.sol
+++ b/script/smoke/V4SmokeTest.s.sol
@@ -151,7 +151,7 @@ contract V4SmokeTest is Script {
         e.poolManager = vm.parseJsonAddress(json, '.latest.PoolManager.address');
         e.positionManager = vm.parseJsonAddress(json, '.latest.PositionManager.address');
         e.stateView = vm.parseJsonAddress(json, '.latest.StateView.address');
-        e.universalRouter = vm.parseJsonAddress(json, '.latest.UniversalRouter.address');
+        e.universalRouter = _resolveUniversalRouter(json);
 
         address v3npm = vm.parseJsonAddress(json, '.latest.NonfungiblePositionManager.address');
         e.weth = INonfungiblePositionManagerV3(v3npm).WETH9();
@@ -162,6 +162,15 @@ contract V4SmokeTest is Script {
         require(e.stateView != address(0), 'StateView not in deployments JSON');
         require(e.universalRouter != address(0), 'UniversalRouter not in deployments JSON');
         require(e.weth != address(0), 'WETH not derivable from v3 NPM');
+    }
+
+    // On chains deployed before UR v2.1.1, `latest.UniversalRouter` points at a router whose
+    // ExactInputSingleParams has no minHopPriceX36 field, so the swap encoding below reverts.
+    // Those chains carry the modern router under `latest."UniversalRouter#v2.2"`, so prefer it.
+    function _resolveUniversalRouter(string memory json) internal view returns (address) {
+        string memory v22Key = '.latest.["UniversalRouter#v2.2"].address';
+        if (vm.keyExistsJson(json, v22Key)) return vm.parseJsonAddress(json, v22Key);
+        return vm.parseJsonAddress(json, '.latest.UniversalRouter.address');
     }
 
     function _logEnv(Env memory e) internal pure {

--- a/script/smoke/native-is-erc20/V4SmokeNativeIsERC20.s.sol
+++ b/script/smoke/native-is-erc20/V4SmokeNativeIsERC20.s.sol
@@ -116,7 +116,7 @@ contract V4SmokeNativeIsERC20 is Script {
         permit2 = vm.parseJsonAddress(json, '.latest.Permit2.address');
         positionManager = vm.parseJsonAddress(json, '.latest.PositionManager.address');
         stateView = vm.parseJsonAddress(json, '.latest.StateView.address');
-        universalRouter = vm.parseJsonAddress(json, '.latest.UniversalRouter.address');
+        universalRouter = _resolveUniversalRouter(json);
 
         require(permit2 != address(0), 'Permit2 not in deployments JSON');
         require(positionManager != address(0), 'PositionManager not in deployments JSON');
@@ -152,6 +152,15 @@ contract V4SmokeNativeIsERC20 is Script {
         console.log('');
         console.log('SUCCESS: v4 (native-is-erc20 variant) pool init + position mint + UR swap completed');
         vm.stopBroadcast();
+    }
+
+    // On chains deployed before UR v2.1.1, `latest.UniversalRouter` points at a router whose
+    // ExactInputSingleParams has no minHopPriceX36 field, so the swap encoding below reverts.
+    // Those chains carry the modern router under `latest."UniversalRouter#v2.2"`, so prefer it.
+    function _resolveUniversalRouter(string memory json) internal view returns (address) {
+        string memory v22Key = '.latest.["UniversalRouter#v2.2"].address';
+        if (vm.keyExistsJson(json, v22Key)) return vm.parseJsonAddress(json, v22Key);
+        return vm.parseJsonAddress(json, '.latest.UniversalRouter.address');
     }
 
     function _approve(TestToken a, TestToken b) internal {


### PR DESCRIPTION
The v4 smoke tests encode swap params in the UR v2.1.1+ layout (with `minHopPriceX36`), but resolve the router from `.latest.UniversalRouter`. On chains deployed before v2.1.1 (e.g. Ink 57073) that key still points at the old router, so the UR swap step reverts with empty data while the newer router sits under `.latest."UniversalRouter#v2.2"`.

This makes both `V4SmokeTest` and `V4SmokeNativeIsERC20` prefer the `UniversalRouter#v2.2` key when present, falling back to `latest.UniversalRouter`.

Verified by fork simulation:
- Ink (57073): both scripts previously reverted at the swap; both now resolve `0x28bD21bB4Ea4fDa370D8d7544992038375D8d456` and pass end to end
- Arc (5042): `V4SmokeNativeIsERC20` still passes via the fallback key (no `#v2.2` entry there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)