### PR TITLE
feat(smoke): add v4 pool seeding scripts + operator guides

### DIFF
--- a/script/smoke/SeedPoolV4-Maple-Robinhood.md
+++ b/script/smoke/SeedPoolV4-Maple-Robinhood.md
@@ -1,0 +1,273 @@
+# Adding liquidity to a syrupUSDG / USDG pool on Robinhood (Uniswap v4, chain 4663)
+
+Instructions for Maple to create and fund a Uniswap v4 pool on Robinhood using Foundry, while the UI
+is not yet available. You provide two token addresses and two token amounts; the script
+(`script/smoke/SeedPoolV4.s.sol`) builds the pool at the ratio your amounts imply and mints a
+concentrated position around the current price (default +/- 1%). No sqrt prices, no encoding.
+
+The script is chain-agnostic: it resolves all Uniswap infra addresses from `deployments/json/4663.json`
+by chain id, so nothing is hardcoded.
+
+---
+
+## What you need
+
+**An RPC that accepts transactions.** Robinhood is an Arbitrum Orbit chain with split endpoints: the
+public Blockscout RPC is read-only, and writes go to the sequencer. `forge script --broadcast` needs one
+RPC that does both reads and writes, which means a Nitro follower node. Ask Robinhood for a node endpoint
+that accepts transactions, or run your own follower. Set it as `RH_RPC` below.
+
+- Read-only steps (the dry run, the quote test) work against the public Blockscout RPC, no node needed.
+- The `--broadcast` steps need the read+write RPC.
+
+**ETH for gas.** Robinhood uses ETH as its gas token (confirmed onchain). Your funding EOA needs a little
+ETH for gas. There is no separate gas-token ERC-20.
+
+**The two tokens.** Your EOA must hold enough syrupUSDG and USDG to cover the amounts you choose.
+Prefer a dedicated seeding EOA over a treasury wallet: the script grants standing Permit2 allowances
+from whichever account runs it.
+
+---
+
+## Tokens (verified onchain on Robinhood 4663)
+
+| Token     | Address                                      | Decimals | Notes                          |
+|-----------|----------------------------------------------|----------|--------------------------------|
+| USDG      | `0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168` | 6        | Global Dollar (Paxos), ~ $1.00 |
+| syrupUSDG | `0x40858070814a57FdF33a613ae84fE0a8b4a874f7` | 6        | Maple yield-bearing (starts at par, accrues over time) |
+
+## Uniswap v4 addresses (chain 4663)
+
+Resolved automatically by the script; listed for reference.
+
+| Contract        | Address                                      |
+|-----------------|----------------------------------------------|
+| PoolManager     | `0x8366a39CC670B4001A1121B8F6A443A643e40951` |
+| PositionManager | `0x58daec3116aae6D93017bAAea7749052E8a04fA7` |
+| StateView       | `0xF3334192D15450CdD385c8B70e03f9A6bD9E673b` |
+| V4Quoter        | `0x8dc178efb8111bb0973dd9d722ebeff267c98f94` |
+| Permit2         | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
+
+---
+
+## How pricing works (read this first)
+
+You do not enter a price. **The starting price is the ratio of the two amounts you deposit.** The script
+sets `price(USDG per syrupUSDG) = AMOUNT_USDG / AMOUNT_syrupUSDG` and mints there.
+
+**The script does not sanity-check this ratio for you.** If you enter the wrong amounts it will
+happily initialize the pool at the wrong price, and initialization cannot be undone. This is exactly
+why Run 1 must be tiny.
+
+**Start the pool at 1:1: deposit equal amounts of syrupUSDG and USDG.** syrupUSDG launches at par with
+USDG and accrues yield over time, so 1:1 is the right starting price at launch.
+
+- Deposit equal raw amounts: `AMOUNT_syrupUSDG == AMOUNT_USDG`.
+- Example: 1000 syrupUSDG with 1000 USDG.
+
+Amounts are in each token's **raw smallest units**. Both tokens have 6 decimals, so multiply whole
+tokens by 1,000,000:
+
+- 1000 syrupUSDG = `1000000000`
+- 1000 USDG = `1000000000`
+
+(If syrupUSDG has already accrued above par by the time you seed, a 1:1 start will be slightly low and a
+small arbitrage will nudge the price up; keeping Run 1 tiny limits that.)
+
+### Seed small first
+
+The price is set once, at initialization, and cannot be reset. So:
+
+1. Initialize and seed a **tiny** amount first (a few tokens), at 1:1.
+2. Confirm it works with the read-only quote below.
+3. Re-run with the full size. The pool is already initialized, so the second run adds liquidity at the
+   pool's current live price without re-pricing.
+
+### Yield drift (worth knowing)
+
+A pool of a yield-bearing token against its underlying slowly becomes underpriced as syrupUSDG accrues
+yield: the real value rises but the pool price only moves when someone swaps, so arbitrageurs buy
+syrupUSDG cheap from the pool and LPs give up the yield over time. The 0.05% fee buffers this (drift
+below the fee is not profitably arbitraged), so for a modest pool it is small. With a concentrated range
+there is a second effect: as the price drifts up it walks toward the upper bound, and once it exits the
+range the position sits entirely in syrupUSDG and stops earning fees. At ~5% APY a +/- 1% band has
+roughly two months of runway before the upper edge. Keep the size modest, monitor it, and re-seed or
+widen the range if it drifts materially. A wider `RANGE_TICKS` buys more runway at the cost of fee
+density.
+
+---
+
+## Step 0: confirm tokens and gas
+
+```bash
+export RH_RPC=<your-robinhood-rpc>     # read+write endpoint for broadcast; Blockscout RPC ok for reads
+export USDG=0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168
+export SYRUP_USDG=0x40858070814a57FdF33a613ae84fE0a8b4a874f7
+
+cast call $USDG       "symbol()(string)"  --rpc-url $RH_RPC   # USDG
+cast call $USDG       "decimals()(uint8)" --rpc-url $RH_RPC   # 6
+cast call $SYRUP_USDG "symbol()(string)"  --rpc-url $RH_RPC   # syrupUSDG
+cast call $SYRUP_USDG "decimals()(uint8)" --rpc-url $RH_RPC   # 6
+
+cast balance <YOUR_EOA> --rpc-url $RH_RPC                                  # ETH for gas
+cast call $USDG       "balanceOf(address)(uint256)" <YOUR_EOA> --rpc-url $RH_RPC
+cast call $SYRUP_USDG "balanceOf(address)(uint256)" <YOUR_EOA> --rpc-url $RH_RPC
+```
+
+---
+
+## Inputs
+
+| Env var    | Meaning                                               | Example       |
+|------------|-------------------------------------------------------|---------------|
+| `TOKEN_A`  | one token address (order does not matter)             | syrupUSDG     |
+| `TOKEN_B`  | the other token address                               | USDG          |
+| `AMOUNT_A` | raw amount of TOKEN_A to deposit (smallest units)     | `1000000000`  |
+| `AMOUNT_B` | raw amount of TOKEN_B to deposit (smallest units)     | `1000000000`  |
+| `RANGE_TICKS` | (optional) ticks on each side of the current price | `100` (default)|
+
+The ratio `AMOUNT_B / AMOUNT_A` (after the script sorts the tokens) is the pool price.
+
+### Range (concentrated, not full range)
+
+The position is concentrated: it spans `RANGE_TICKS` ticks on each side of the current price, not the
+whole curve. With this pool's tick spacing (10), 1 tick is about 0.01%, so `RANGE_TICKS` of 100 is about
++/- 1%. If you do not set it, it defaults to 100. The bounds are aligned to the tick spacing and clamped
+to the usable range.
+
+Why concentrate: for a stablecoin / correlated pair, putting the liquidity in a tight band around the
+price is far more capital-efficient than full range (more fee revenue per dollar deposited), because the
+price rarely leaves the band. `100` (+/- 1%) is the recommended default: tight enough to be efficient,
+wide enough to cover normal stablecoin movement, and it gives syrupUSDG's upward yield drift roughly two
+months of runway at ~5% APY before the price walks out the top.
+
+Tradeoffs, with the actual bounds and liquidity for this pair (starting price 1:1 = tick 0, depositing
+2 syrupUSDG / 2 USDG, from a live dry run):
+
+| `RANGE_TICKS` | approx band | tickLower / tickUpper | liquidity (denser = more fees) |
+|---------------|-------------|-----------------------|--------------------------------|
+| `10`          | +/- 0.1%    | -10 / 10              | 4,001,200,079                  |
+| `50`          | +/- 0.5%    | -50 / 50              | 801,040,415                    |
+| `100` (default) | +/- 1%    | -100 / 100           | 401,020,832                    |
+| `200`         | +/- 2%      | -200 / 200           | 201,011,666                    |
+
+Tighter earns more fees but exits the range sooner (during any depeg, or as syrupUSDG yield pushes the
+price up); wider is safer but less dense. If the price leaves the range, the position sits entirely in
+one token and stops earning until you re-seed or widen it, so monitor it.
+
+Set it like any other input, for example a tighter half-percent band:
+
+```bash
+export RANGE_TICKS=50
+```
+
+The script also needs two unused env vars so `foundry.toml` parses:
+
+```bash
+export TENDERLY_PUBLIC_RPC_URL=http://x
+export TENDERLY_ACCESS_KEY=dummy
+```
+
+---
+
+## Run 1: tiny test seed (this sets the starting price)
+
+Seed a tiny 2 syrupUSDG / 2 USDG (1:1) to start.
+
+```bash
+export TOKEN_A=$SYRUP_USDG
+export TOKEN_B=$USDG
+export AMOUNT_A=2000000     # 2 syrupUSDG
+export AMOUNT_B=2000000     # 2 USDG  -> 1:1 starting price
+
+# Dry run first (no broadcast). Read the logged amounts/price and confirm they look right.
+forge script script/smoke/SeedPoolV4.s.sol \
+  --rpc-url $RH_RPC --sender <YOUR_EOA> --skip '*/node_modules/*'
+
+# Broadcast (needs the read+write RPC):
+forge script script/smoke/SeedPoolV4.s.sol \
+  --rpc-url $RH_RPC --account <keystore-name> --sender <YOUR_EOA> \
+  --broadcast --slow --legacy --with-gas-price 200000000 --gas-estimate-multiplier 400 \
+  --skip '*/node_modules/*'
+```
+
+Why these flags on Robinhood (an Orbit chain):
+- `--slow`: submit nonces sequentially; avoids reordering on sequencer-driven chains.
+- `--legacy`: Robinhood's RPC path is happiest with legacy gas pricing.
+- `--with-gas-price 200000000`: 0.2 gwei; this is the actual broadcast price (not `--gas-price`, which
+  only affects simulation).
+- `--gas-estimate-multiplier 400`: the small approval txs otherwise get rejected as
+  `intrinsic gas too low` because forge's local sizing does not model Orbit's L1-data gas. Excess gas is
+  rebated, so over-budgeting is free.
+
+---
+
+## Test it (read-only quote, does not move the price)
+
+Sorted by address, `c0 = syrupUSDG`, `c1 = USDG`. `zeroForOne=true` sells syrupUSDG. `1000000` is 1 token
+(6 decimals).
+
+```bash
+cast call 0x8dc178efb8111bb0973dd9d722ebeff267c98f94 \
+  "quoteExactInputSingle(((address,address,uint24,int24,address),bool,uint128,bytes))(uint256,uint256)" \
+  "(($SYRUP_USDG,$USDG,500,10,0x0000000000000000000000000000000000000000),true,1000000,0x)" \
+  --rpc-url $RH_RPC
+```
+
+Returns `(amountOut, gasEstimate)` and simulates the swap without changing the pool price.
+
+**Expect the quoted rate to look bad at this stage.** Quoting 1 whole token against a 2-token seed has
+heavy price impact, so `amountOut` will come back noticeably below 1:1. That is depth, not mispricing.
+Check that the direction and rough ratio make sense (or quote a much smaller amount); the rate tightens
+up once the full liquidity is in.
+
+---
+
+## Run 2: top up to full size (price unchanged)
+
+Re-run with the full amounts. The script detects the pool is already initialized, reads the live price
+from StateView, and adds liquidity there without re-pricing. At the live price the deposit consumes the
+full amount of the binding side and up to the requested amount of the other side.
+
+```bash
+export AMOUNT_A=1000000000     # 1000 syrupUSDG
+export AMOUNT_B=1000000000     # 1000 USDG  (1:1)
+forge script script/smoke/SeedPoolV4.s.sol \
+  --rpc-url $RH_RPC --account <keystore-name> --sender <YOUR_EOA> \
+  --broadcast --slow --legacy --with-gas-price 200000000 --gas-estimate-multiplier 400 \
+  --skip '*/node_modules/*'
+```
+
+---
+
+## What the script does (and its safety checks)
+
+- Resolves all infra addresses from `deployments/json/4663.json` (nothing hardcoded).
+- Sorts the tokens (`currency0 < currency1`) and keeps amounts aligned. You can pass them in any order.
+- First run: sets the starting price to `AMOUNT_B / AMOUNT_A` (after sorting) and initializes. Later runs:
+  funds at the live price read from StateView.
+- Uses the 0.05% fee tier and a concentrated position spanning `RANGE_TICKS` (default 100, ~ +/- 1%)
+  ticks on each side of the current price, aligned to the tick spacing.
+- Permit2 dual-approval, then `modifyLiquidities` (mint + settle).
+- Checks your token balances before minting, and asserts pool liquidity increased afterward.
+
+(The no-price-sanity-check warning from "How pricing works" applies here too: the script deposits
+whatever ratio you give it.)
+
+## Validation status
+
+The script was run end-to-end against a fork of a live Robinhood (4663) node using the real syrupUSDG and
+USDG contracts:
+
+- Both tokens are freely transferable into the PositionManager (no whitelist or transfer restriction).
+- Depositing syrupUSDG and USDG 1:1 initialized the pool at par (tick 0).
+- Dry runs of the final script against live Robinhood state created the concentrated position at
+  `RANGE_TICKS` of 10, 50, 100 (default) and 200, with correctly aligned symmetric bounds (e.g. -100 / 100
+  for the default +/- 1%) and liquidity scaling as expected (tighter range = denser liquidity). All succeeded.
+- The pool does not exist yet on Robinhood, so the first broadcast will create it; this is why the
+  starting ratio on Run 1 matters and why Run 1 should be tiny.
+
+## References
+
+- Script: `script/smoke/SeedPoolV4.s.sol`
+- Uniswap v4 docs: https://docs.uniswap.org/contracts/v4/overview

--- a/script/smoke/SeedPoolV4.s.sol
+++ b/script/smoke/SeedPoolV4.s.sol
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: MIT
+// ^0.8.20 to match the sibling smoke scripts in this directory (these are not deployed).
+pragma solidity ^0.8.20;
+
+import {Script, console2 as console} from 'forge-std/Script.sol';
+
+// Real v4 math libraries (briefcase copies are self-contained, pragma ^0.8.0).
+import {FullMath} from '../../src/briefcase/protocols/v4-core/libraries/FullMath.sol';
+import {TickMath} from '../../src/briefcase/protocols/v4-core/libraries/TickMath.sol';
+import {LiquidityAmounts} from '../../src/briefcase/protocols/v4-periphery/libraries/LiquidityAmounts.sol';
+
+interface IERC20Min {
+    function approve(address spender, uint256 amount) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function balanceOf(address) external view returns (uint256);
+    function symbol() external view returns (string memory);
+    function decimals() external view returns (uint8);
+}
+
+interface IPermit2 {
+    function approve(address token, address spender, uint160 amount, uint48 expiration) external;
+    function allowance(address user, address token, address spender)
+        external
+        view
+        returns (uint160 amount, uint48 expiration, uint48 nonce);
+}
+
+// Mirrors PoolKey from v4-core
+struct PoolKey {
+    address currency0;
+    address currency1;
+    uint24 fee;
+    int24 tickSpacing;
+    address hooks;
+}
+
+interface IPositionManager {
+    function initializePool(PoolKey calldata key, uint160 sqrtPriceX96) external returns (int24);
+    function modifyLiquidities(bytes calldata unlockData, uint256 deadline) external payable;
+    function nextTokenId() external view returns (uint256);
+}
+
+interface IStateView {
+    function getSlot0(bytes32 poolId)
+        external
+        view
+        returns (uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee);
+    function getLiquidity(bytes32 poolId) external view returns (uint128 liquidity);
+}
+
+/// @notice Creates AND funds a Uniswap v4 pool from two raw token amounts, as a concentrated position.
+///
+/// @dev AMOUNT-NATIVE INTERFACE. You give two token addresses and two raw amounts (in each token's
+///      smallest units). The script sorts the tokens, sets the starting price to the ratio implied by
+///      the amounts, and mints a concentrated position around it. It does NOT know or care about:
+///        - USD prices, NAV, yield, or rebasing. You encode whatever ratio you want into the amounts.
+///        - token decimals. The price is the raw amount ratio, which is exactly the v4 raw price, so any
+///          decimal combination works.
+///        - token order / direction. Pass the tokens in any order; the script sorts internally.
+///
+///      The pool price is whatever AMOUNT_B/AMOUNT_A (after sorting) works out to. To price a
+///      yield-bearing token correctly, deposit the two sides in the ratio of their current values
+///      (e.g. for 1 syrupUSDG = 1.05 USDG, deposit 1.05 USDG for every 1 syrupUSDG). That ratio is the
+///      operator's responsibility; the script just deposits what you give it.
+///
+///      The position is concentrated: it spans RANGE_TICKS ticks on EACH side of the current price
+///      (not full range). With tickSpacing 10, 1 tick ~= 0.01%, so the default 100 ticks ~= +/- 1%,
+///      a sensible band for a stablecoin / correlated pair. Widen for more drift runway, tighten for
+///      more fee density. The bounds are aligned to tickSpacing and clamped to the usable range.
+///
+///      Env vars:
+///        TOKEN_A, TOKEN_B   token addresses (order does not matter; sorted internally)
+///        AMOUNT_A, AMOUNT_B raw amount of each token to deposit, in that token's smallest units
+///                           (e.g. 1000 USDG with 6 decimals = 1000000000)
+///        RANGE_TICKS        (optional) ticks on each side of the current price. Default 100 (~ +/- 1%).
+///
+///      STAGED FUNDING (run more than once):
+///        - 1st run sets the pool's STARTING price from AMOUNT_B/AMOUNT_A and mints. Initialization
+///          happens once per pool (you cannot re-initialize). Start small so a wrong ratio is cheap.
+///        - Later runs skip init and add liquidity at the pool's CURRENT live price (read from
+///          StateView). At the live price the deposit consumes the requested amount of the binding side
+///          and <= the requested amount of the other side.
+contract SeedPoolV4 is Script {
+    // v4 Action codes
+    uint8 constant MINT_POSITION = 0x02;
+    uint8 constant SETTLE_PAIR = 0x0d;
+
+    // Pool params. In v4 ANY fee/tickSpacing combo is allowed; edit these if you want a different tier.
+    uint24 constant FEE = 500; // 0.05%
+    int24 constant TICK_SPACING = 10;
+
+    // Default position half-width, in ticks, used when RANGE_TICKS is not set. With tickSpacing 10,
+    // 1 tick ~= 0.01%, so 100 ticks ~= +/- 1% around the current price: a sensible stablecoin default.
+    uint256 constant DEFAULT_RANGE_TICKS = 100;
+
+    struct Env {
+        address permit2;
+        address poolManager;
+        address positionManager;
+        address stateView;
+    }
+
+    function run() public {
+        Env memory e = _loadEnv();
+
+        // --- Inputs (raw token amounts; no prices) ---
+        address tokenA = vm.envAddress('TOKEN_A');
+        address tokenB = vm.envAddress('TOKEN_B');
+        uint256 amtA = vm.envUint('AMOUNT_A');
+        uint256 amtB = vm.envUint('AMOUNT_B');
+
+        require(tokenA != address(0) && tokenB != address(0), 'token addr zero');
+        require(tokenA != tokenB, 'tokens identical');
+        require(amtA > 0 && amtB > 0, 'amount zero');
+
+        // Order by address: currency0 < currency1. Keep amounts aligned with the sorted tokens.
+        (address c0, address c1, uint256 amount0, uint256 amount1) =
+            tokenA < tokenB ? (tokenA, tokenB, amtA, amtB) : (tokenB, tokenA, amtB, amtA);
+
+        PoolKey memory key =
+            PoolKey({currency0: c0, currency1: c1, fee: FEE, tickSpacing: TICK_SPACING, hooks: address(0)});
+        bytes32 poolId = keccak256(abi.encode(key));
+
+        // If already initialized, fund at the LIVE price (top-up); otherwise set the starting price from
+        // the raw amount ratio: price(token1/token0) = amount1 / amount0.
+        (uint160 livePrice, int24 liveTick,,) = IStateView(e.stateView).getSlot0(poolId);
+        bool alreadyInitialized = livePrice != 0;
+        uint160 sqrtPriceX96 = alreadyInitialized ? livePrice : _sqrtPriceFromAmounts(amount0, amount1);
+        int24 currentTick = alreadyInitialized ? liveTick : TickMath.getTickAtSqrtPrice(sqrtPriceX96);
+
+        // Concentrated range: RANGE_TICKS ticks on each side of the current price, aligned to tickSpacing
+        // and clamped to the usable range.
+        uint256 rangeRaw = vm.envOr('RANGE_TICKS', DEFAULT_RANGE_TICKS);
+        require(rangeRaw > 0 && rangeRaw <= uint256(uint24(TickMath.MAX_TICK)), 'RANGE_TICKS out of range');
+        int24 rangeTicks = int24(int256(rangeRaw));
+
+        int24 tickLower = _floorToSpacing(currentTick - rangeTicks, TICK_SPACING);
+        int24 tickUpper = _ceilToSpacing(currentTick + rangeTicks, TICK_SPACING);
+        int24 minTick = TickMath.minUsableTick(TICK_SPACING);
+        int24 maxTick = TickMath.maxUsableTick(TICK_SPACING);
+        if (tickLower < minTick) tickLower = minTick;
+        if (tickUpper > maxTick) tickUpper = maxTick;
+        require(tickUpper > tickLower, 'empty tick range');
+
+        uint160 sqrtLower = TickMath.getSqrtPriceAtTick(tickLower);
+        uint160 sqrtUpper = TickMath.getSqrtPriceAtTick(tickUpper);
+
+        // Liquidity the amounts buy at the (live or implied) price within [tickLower, tickUpper]. This is
+        // the binding minimum of the two sides; with amount maxes = uint128.max the deposit consumes the
+        // binding side fully and <= the requested amount of the other.
+        uint128 liquidity =
+            LiquidityAmounts.getLiquidityForAmounts(sqrtPriceX96, sqrtLower, sqrtUpper, amount0, amount1);
+        require(liquidity > 0, 'computed liquidity is zero');
+
+        console.log('current tick:');
+        console.logInt(currentTick);
+        console.log('range ticks each side:');
+        console.logInt(rangeTicks);
+        console.log('tickLower:');
+        console.logInt(tickLower);
+        console.log('tickUpper:');
+        console.logInt(tickUpper);
+
+        vm.startBroadcast();
+        address me = msg.sender;
+
+        _logSetup(e, key, c0, c1, amount0, amount1, liquidity, sqrtPriceX96, alreadyInitialized, me);
+
+        require(
+            IERC20Min(c0).balanceOf(me) >= amount0,
+            string.concat('insufficient ', IERC20Min(c0).symbol(), ' (currency0) balance')
+        );
+        require(
+            IERC20Min(c1).balanceOf(me) >= amount1,
+            string.concat('insufficient ', IERC20Min(c1).symbol(), ' (currency1) balance')
+        );
+
+        if (!alreadyInitialized) {
+            IPositionManager(e.positionManager).initializePool(key, sqrtPriceX96);
+            console.log('Pool initialized at the amount-implied starting price (init happens once per pool).');
+        } else {
+            console.log('Pool already initialized; topping up at the live price (price unchanged).');
+        }
+
+        _approvePermit2(c0, c1, e, me);
+
+        uint128 liqBefore = IStateView(e.stateView).getLiquidity(poolId);
+        uint256 tokenId = IPositionManager(e.positionManager).nextTokenId();
+
+        // amount maxes: requested amount + 1% headroom. The liquidity was derived as the binding minimum of
+        // the two sides, so the pool can never need more than `amount` plus round-up dust at the quoted
+        // price; the 1% buffer absorbs that rounding plus small price movement between simulation and
+        // inclusion. If the price is shoved further than 1% mid-flight, the mint reverts instead of
+        // depositing at the manipulated price.
+        uint128 amount0Max = _withBuffer(amount0);
+        uint128 amount1Max = _withBuffer(amount1);
+        bytes memory actions = abi.encodePacked(MINT_POSITION, SETTLE_PAIR);
+        bytes[] memory params = new bytes[](2);
+        params[0] = abi.encode(key, tickLower, tickUpper, uint256(liquidity), amount0Max, amount1Max, me, bytes(''));
+        params[1] = abi.encode(key.currency0, key.currency1);
+
+        IPositionManager(e.positionManager).modifyLiquidities(abi.encode(actions, params), block.timestamp + 3600);
+        console.log('Minted v4 position tokenId:', tokenId);
+
+        _verifyPool(e.stateView, poolId, tokenId, liqBefore);
+
+        console.log('');
+        console.log('SUCCESS: v4 pool created/topped up with concentrated liquidity');
+        vm.stopBroadcast();
+    }
+
+    /// @notice sqrtPriceX96 from the raw amount ratio. price(token1/token0) = amount1 / amount0.
+    function _sqrtPriceFromAmounts(uint256 amount0, uint256 amount1) internal pure returns (uint160) {
+        // inner = (amount1/amount0) * 2^192  ->  sqrt(inner) = sqrt(price) * 2^96 = sqrtPriceX96
+        uint256 inner = FullMath.mulDiv(amount1, uint256(1) << 192, amount0);
+        uint256 sp = _sqrt(inner);
+        require(sp > TickMath.MIN_SQRT_PRICE && sp < TickMath.MAX_SQRT_PRICE, 'price out of range');
+        return uint160(sp);
+    }
+
+    /// @notice Floor integer square root (Babylonian method).
+    function _sqrt(uint256 x) internal pure returns (uint256) {
+        if (x == 0) return 0;
+        uint256 z = (x + 1) / 2;
+        uint256 y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
+        return y;
+    }
+
+    /// @notice Round a tick down to the nearest multiple of `spacing` (toward negative infinity).
+    function _floorToSpacing(int24 tick, int24 spacing) internal pure returns (int24) {
+        int24 q = tick / spacing;
+        if (tick % spacing != 0 && tick < 0) q -= 1;
+        return q * spacing;
+    }
+
+    /// @notice Round a tick up to the nearest multiple of `spacing` (toward positive infinity).
+    function _ceilToSpacing(int24 tick, int24 spacing) internal pure returns (int24) {
+        int24 q = tick / spacing;
+        if (tick % spacing != 0 && tick > 0) q += 1;
+        return q * spacing;
+    }
+
+    function _loadEnv() internal view returns (Env memory e) {
+        string memory path = string.concat('./deployments/json/', vm.toString(block.chainid), '.json');
+        string memory json = vm.readFile(path);
+
+        e.permit2 = vm.parseJsonAddress(json, '.latest.Permit2.address');
+        e.poolManager = vm.parseJsonAddress(json, '.latest.PoolManager.address');
+        e.positionManager = vm.parseJsonAddress(json, '.latest.PositionManager.address');
+        e.stateView = vm.parseJsonAddress(json, '.latest.StateView.address');
+
+        require(e.permit2 != address(0), 'Permit2 not in deployments JSON');
+        require(e.poolManager != address(0), 'PoolManager not in deployments JSON');
+        require(e.positionManager != address(0), 'PositionManager not in deployments JSON');
+        require(e.stateView != address(0), 'StateView not in deployments JSON');
+    }
+
+    /// @notice Requested amount plus 1% headroom, saturating at uint128.max.
+    function _withBuffer(uint256 amount) internal pure returns (uint128) {
+        uint256 buffered = amount + amount / 100 + 1;
+        return buffered > type(uint128).max ? type(uint128).max : uint128(buffered);
+    }
+
+    function _approvePermit2(address c0, address c1, Env memory e, address me) internal {
+        // Only issue approvals that are actually missing, so re-runs (top-ups) don't emit redundant
+        // infinite-approval transactions.
+        // Step 1: let Permit2 pull tokens from msg.sender.
+        if (IERC20Min(c0).allowance(me, e.permit2) != type(uint256).max) {
+            IERC20Min(c0).approve(e.permit2, type(uint256).max);
+        }
+        if (IERC20Min(c1).allowance(me, e.permit2) != type(uint256).max) {
+            IERC20Min(c1).approve(e.permit2, type(uint256).max);
+        }
+        // Step 2: give PositionManager spender allowance via Permit2.
+        (uint160 amt0, uint48 exp0,) = IPermit2(e.permit2).allowance(me, c0, e.positionManager);
+        if (amt0 != type(uint160).max || exp0 != type(uint48).max) {
+            IPermit2(e.permit2).approve(c0, e.positionManager, type(uint160).max, type(uint48).max);
+        }
+        (uint160 amt1, uint48 exp1,) = IPermit2(e.permit2).allowance(me, c1, e.positionManager);
+        if (amt1 != type(uint160).max || exp1 != type(uint48).max) {
+            IPermit2(e.permit2).approve(c1, e.positionManager, type(uint160).max, type(uint48).max);
+        }
+        console.log('Permit2 allowances in place for PositionManager (skipped any already granted)');
+    }
+
+    function _logSetup(
+        Env memory e,
+        PoolKey memory key,
+        address c0,
+        address c1,
+        uint256 amount0,
+        uint256 amount1,
+        uint128 liquidity,
+        uint160 sqrtPriceX96,
+        bool alreadyInitialized,
+        address me
+    ) internal view {
+        console.log('Chain:', block.chainid);
+        console.log('Sender:', me);
+        console.log('PoolManager:', e.poolManager);
+        console.log('PositionManager:', e.positionManager);
+        console.log('StateView:', e.stateView);
+        console.log('Permit2:', e.permit2);
+        console.log('pool already initialized:', alreadyInitialized);
+        console.log('currency0:', c0);
+        console.log('  symbol:', IERC20Min(c0).symbol());
+        console.log('  amount0 to deposit (raw):', amount0);
+        console.log('currency1:', c1);
+        console.log('  symbol:', IERC20Min(c1).symbol());
+        console.log('  amount1 to deposit (raw):', amount1);
+        console.log('fee:', key.fee);
+        console.log('sqrtPriceX96 (from amount ratio):', sqrtPriceX96);
+        console.log('computed liquidity:', liquidity);
+    }
+
+    function _verifyPool(address stateView, bytes32 poolId, uint256 tokenId, uint128 liqBefore) internal view {
+        (uint160 sqrtPriceX96, int24 tick,,) = IStateView(stateView).getSlot0(poolId);
+        uint128 liqAfter = IStateView(stateView).getLiquidity(poolId);
+        console.log('Pool id:');
+        console.logBytes32(poolId);
+        console.log('Pool slot0 sqrtPriceX96:', sqrtPriceX96);
+        console.log('Pool tick:', tick);
+        console.log('pool liquidity before:', liqBefore);
+        console.log('pool liquidity after:', liqAfter);
+        require(liqAfter > liqBefore, 'liquidity did not increase');
+        require(tokenId > 0, 'no position minted');
+    }
+}

--- a/script/smoke/SeedStablePoolV4-Arc.md
+++ b/script/smoke/SeedStablePoolV4-Arc.md
@@ -1,0 +1,198 @@
+# Seeding a USDC/EURC pool on Arc (Uniswap v4, chain 5042)
+
+Guide for creating and funding a single test pool without a UI, using Foundry. Written for the
+Arc / LI.FI same-chain swap testing requirement. Uses Uniswap v4.
+
+> **Status:** the 0.05% USDC/EURC pool on Arc was initialized and seeded on 2026-08-04, so on this
+> pair the script now always takes the top-up path (it detects the live pool and adds liquidity at
+> the current price). The init instructions below still apply to any new pair.
+
+---
+
+## Why seed small first
+
+The pool price is NOT fixed: it floats with every swap, like any AMM. The only thing that happens
+once is initialization: `initializePool` sets the starting price and can only be called once per
+pool, so you can't re-initialize to reset a bad starting price.
+
+If you initialize at the wrong starting price, the pool is mispriced versus the market. An
+arbitrageur trades against it to pull it to the true price and keeps the difference, and that loss
+scales with how much liquidity you posted. Correcting a bad starting price yourself means swapping
+the pool back, which costs fees/spread. With a tiny position that's cheap; with a big one it's a
+real loss.
+
+So the safe sequence is:
+
+1. **Initialize + seed a tiny amount first** (a few dollars), using a live FX quote for the price.
+   If the starting price is off, only a few dollars are exposed and it's cheap to nudge back.
+2. **Run a test quote / let LI.FI route against it** to confirm everything works.
+3. **Top up to the full ~$1k/$1k** once confirmed. The pool is already initialized, so the top-up
+   adds liquidity at the pool's current live price (wherever swaps have left it); it does not
+   re-initialize.
+
+The script is built to be run exactly this way: run it once with a small budget, then run it again
+with the full budget.
+
+## You never touch ticks or sqrt prices
+
+You only ever provide USD prices (and a USD budget). The script converts those into the v4
+`sqrtPriceX96`, the tick range, and the liquidity for you. Use a live FX quote for the prices on
+the first run, since that run sets the pool's starting price (see above).
+
+---
+
+## Deployed Uniswap v4 addresses on Arc (chain 5042)
+
+Explorer: https://explorer.arc.io. Resolved automatically by the script from
+`deployments/json/5042.json`; listed here for reference.
+
+| Contract        | Address                                      |
+|-----------------|----------------------------------------------|
+| PoolManager     | `0x8366a39CC670B4001A1121B8F6A443A643e40951` |
+| PositionManager | `0x6049c9a0e26405C0985f9E3685C87d0aE917f82B` |
+| StateView       | `0xF3334192D15450CdD385c8B70e03f9A6bD9E673b` |
+| V4Quoter        | `0x8dC178eFB8111Bb0973dd9D722EbEfF267c98F94` |
+| UniversalRouter | `0x4fcA4a51Ab4F23A7447b3284fBd7D73289A89Fb1` |
+| Permit2         | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
+
+---
+
+## Step 0: confirm tokens and gas (do this first)
+
+We never hardcode token addresses. Confirm the canonical USDC and EURC addresses on Arc from
+Circle's docs, then verify onchain:
+
+```bash
+export ARC_RPC=<arc-rpc-url>
+cast call <USDC> "symbol()(string)"   --rpc-url $ARC_RPC   # expect USDC
+cast call <USDC> "decimals()(uint8)"  --rpc-url $ARC_RPC   # expect 6
+cast call <EURC> "symbol()(string)"   --rpc-url $ARC_RPC   # expect EURC
+cast call <EURC> "decimals()(uint8)"  --rpc-url $ARC_RPC   # expect 6
+```
+
+Both are 6 decimals, so the script's equal-decimals path applies.
+
+**Gas note:** Arc's native gas token is an ERC-20 (not ETH). Your funding EOA must hold some of
+Arc's native token to pay for transactions. The USDC/EURC pool itself never touches the native
+token.
+
+Prefer a dedicated seeding EOA over a treasury wallet: the script grants standing Permit2
+allowances from whichever account runs it.
+
+---
+
+## The script
+
+`script/smoke/SeedStablePoolV4.s.sol` creates the pool (first run) and funds it, in one
+transaction. It mirrors the v4 encoding from the smoke test that is already proven to work on Arc
+(`script/smoke/native-is-erc20/V4SmokeNativeIsERC20.s.sol`): same action codes, same
+`modifyLiquidities` encoding, same Permit2 dual-approval. It uses the 0.05% fee tier and a
+full-range position.
+
+## Inputs (all USD figures scaled by 1e8, "Chainlink style")
+
+| Env var            | Meaning                              | Example                                       |
+|--------------------|--------------------------------------|-----------------------------------------------|
+| `TOKEN_A`          | one token address (e.g. USDC)        | `0x...`                                       |
+| `TOKEN_B`          | the other token address (e.g. EURC)  | `0x...`                                       |
+| `PRICE_A_USD_8DP`  | USD price of 1 TOKEN_A × 1e8         | $1.00 → `100000000`                           |
+| `PRICE_B_USD_8DP`  | USD price of 1 TOKEN_B × 1e8         | $1.08 → `108000000`                           |
+| `USD_PER_SIDE_8DP` | USD value to deposit per side × 1e8  | $2 test → `200000000`; $1000 → `100000000000` |
+
+The rule for the 1e8 scale: multiply the dollar figure by `100000000`. Use a real EUR/USD quote for
+`PRICE_B_USD_8DP` at run time.
+
+---
+
+## Run 1: tiny test seed (this sets the starting price)
+
+```bash
+export ARC_RPC=<arc-rpc-url>
+export TOKEN_A=<USDC>
+export TOKEN_B=<EURC>
+export PRICE_A_USD_8DP=100000000     # USDC $1.00
+export PRICE_B_USD_8DP=108000000     # EURC $1.08  <-- use the live rate
+export USD_PER_SIDE_8DP=200000000    # $2 per side for the test
+
+# Dry run first (no broadcast). Read the logged amounts/price and confirm they look right:
+forge script script/smoke/SeedStablePoolV4.s.sol --rpc-url $ARC_RPC --sender <YOUR_EOA> \
+  --skip '*/node_modules/*'
+
+# Broadcast:
+forge script script/smoke/SeedStablePoolV4.s.sol \
+  --rpc-url $ARC_RPC --account <keystore-name> --sender <YOUR_EOA> --broadcast \
+  --skip '*/node_modules/*'
+```
+
+Arc gas: if a tx gets stuck, prior Arc deploys have used `--legacy --gas-price 200000000`. Add
+those flags if you hit replacement/underpriced errors.
+
+---
+
+## Test it (read-only quote, does not move the price)
+
+Quote a small swap to prove the pool is routable (V4Quoter):
+
+```bash
+cast call 0x8dC178eFB8111Bb0973dd9D722EbEfF267c98F94 \
+  "quoteExactInputSingle(((address,address,uint24,int24,address),bool,uint128,bytes))(uint256,uint256)" \
+  "((<c0>,<c1>,500,10,0x0000000000000000000000000000000000000000),<zeroForOne>,1000000,0x)" \
+  --rpc-url $ARC_RPC
+```
+
+`<c0>`/`<c1>` are USDC/EURC sorted by address (lower address is c0). `zeroForOne=true` means
+selling c0. Then point LI.FI at the pool for their same-chain swap test.
+
+**Expect the quoted rate to look bad at this stage.** Quoting 1 whole token against only a few
+dollars of seeded depth has heavy price impact, so `amountOut` will come back noticeably below the
+FX rate. That is depth, not mispricing. Check that the direction and rough ratio make sense (or
+quote a much smaller amount); the rate tightens up once the full liquidity is in.
+
+---
+
+## Run 2: top up to full size (price unchanged)
+
+Re-run with the real budget. The script detects the pool is already initialized, reads the live
+price from StateView, and adds liquidity there without re-pricing.
+
+Two things about this run:
+
+- **Re-export every env var, not just the budget** (fresh shells lose them, and the script needs
+  the prices to size the amounts). Refresh `PRICE_B_USD_8DP` from a live EUR/USD quote at the same
+  time.
+- **A leftover on one side is normal.** The prices size the two amounts, but the pool's live price
+  decides the exact ratio it accepts; the script deposits the binding side in full and up to the
+  requested amount of the other. Whatever isn't consumed stays in your wallet, nothing is lost.
+
+```bash
+export TOKEN_A=<USDC>
+export TOKEN_B=<EURC>
+export PRICE_A_USD_8DP=100000000       # USDC $1.00
+export PRICE_B_USD_8DP=108000000       # refresh with the live EUR/USD rate
+export USD_PER_SIDE_8DP=100000000000   # $1000 per side
+forge script script/smoke/SeedStablePoolV4.s.sol \
+  --rpc-url $ARC_RPC --account <keystore-name> --sender <YOUR_EOA> --broadcast \
+  --skip '*/node_modules/*'
+```
+
+---
+
+## What the script does (and safety checks)
+
+- Resolves all infra addresses from `deployments/json/5042.json` (nothing hardcoded).
+- Sorts the tokens (`currency0 < currency1`) and keeps prices/amounts aligned.
+- Requires equal decimals (the USD→price math assumes it).
+- First run: computes `sqrtPriceX96` from the USD prices and initializes. Later runs: funds at the
+  live price.
+- Derives token amounts from `USD_PER_SIDE_8DP` and the prices, and the liquidity from those
+  amounts.
+- Permit2 dual-approval (skipping any allowance already granted), then `modifyLiquidities`
+  (`MINT_POSITION` + `SETTLE_PAIR`), full range, with amount caps at the computed amounts +1% so a
+  price moved mid-flight reverts the mint instead of depositing at the manipulated price.
+- Checks your balances before minting and asserts pool liquidity increased after.
+
+## References
+
+- Uniswap v4 docs: https://docs.uniswap.org/contracts/v4/overview
+- Proven-on-Arc v4 flow: `script/smoke/native-is-erc20/V4SmokeNativeIsERC20.s.sol`
+- All Arc deployments: `deployments/5042.md`

--- a/script/smoke/SeedStablePoolV4-Robinhood.md
+++ b/script/smoke/SeedStablePoolV4-Robinhood.md
@@ -1,0 +1,287 @@
+# Seeding a Uniswap v4 pool on Robinhood (chain 4663)
+
+Guide for creating and funding a single Uniswap v4 pool on Robinhood without a UI, using Foundry.
+You only ever supply USD prices and a USD budget; the script (`script/smoke/SeedStablePoolV4.s.sol`)
+derives the v4 price, tick range, and liquidity for you. No ticks, no sqrt prices, no hand-encoding.
+
+The script is chain-agnostic: it resolves all infra addresses from `deployments/json/4663.json` by
+chain id, so nothing is hardcoded.
+
+---
+
+## Do you need to run a node?
+
+Robinhood is an Arbitrum Orbit chain with split endpoints: the public Blockscout RPC is **read-only**,
+and writes go to the sequencer. `forge script --broadcast` needs one RPC that does **both** reads and
+writes, which on Robinhood means a Nitro follower node.
+
+- **Read-only steps work on the public Blockscout RPC, no node needed:** the dry-run (no `--broadcast`)
+  and the V4Quoter quote-test.
+- **The `--broadcast` steps need a read+write RPC.** Ask Robinhood for a node endpoint that accepts
+  transactions, or run your own follower node. Set that as `RH_RPC` below.
+
+## Gas
+
+Robinhood uses **ETH** as the gas token (confirmed onchain: the L1 bridge has no custom native token).
+Your deploy EOA just needs a little ETH for gas. There is no separate gas-token ERC-20 to source.
+
+---
+
+## Why seed small first (read this before Run 1)
+
+A v4 pool's price is **not** fixed: it floats with every swap, like any AMM. The only thing that
+happens once is **initialization**: `initializePool` sets the starting price and can only be called
+once per pool. You cannot re-initialize to reset a bad starting price.
+
+If you initialize at the wrong starting price, the pool is mispriced versus the market. An arbitrageur
+trades against it to pull it to the true price and keeps the difference, and that loss scales with how
+much liquidity you posted. So:
+
+1. **Initialize + seed a tiny amount first** (a few dollars), using a live price quote. If the starting
+   price is off, only a few dollars are exposed.
+2. **Test** with the read-only quote (and/or let the integrator route against it) to confirm it works.
+3. **Top up to full size** once confirmed. The pool is already initialized, so the top-up adds liquidity
+   at the pool's current live price (wherever swaps have left it); it does **not** re-initialize.
+
+The script is built to be run exactly this way: run it once with a small budget, then again with the
+full budget.
+
+---
+
+## Deployed Uniswap v4 addresses on Robinhood (chain 4663)
+
+Resolved automatically by the script from `deployments/json/4663.json`; listed here for reference.
+
+| Contract        | Address                                      |
+|-----------------|----------------------------------------------|
+| PoolManager     | `0x8366a39CC670B4001A1121B8F6A443A643e40951` |
+| PositionManager | `0x58daec3116aae6D93017bAAea7749052E8a04fA7` |
+| StateView       | `0xF3334192D15450CdD385c8B70e03f9A6bD9E673b` |
+| V4Quoter        | `0x8dc178efb8111bb0973dd9d722ebeff267c98f94` |
+| UniversalRouter | `0x8876789976decBfcbBBe364623c63652Db8C0904` |
+| Permit2         | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
+| WETH9           | `0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73` |
+
+---
+
+## This pair: syrupUSDG / USDG
+
+Both tokens are verified onchain on Robinhood (4663) and are **6 decimals**, so the equal-decimals
+path applies and the script runs unchanged.
+
+| Token     | Address                                      | Decimals | Notes                          |
+|-----------|----------------------------------------------|----------|--------------------------------|
+| USDG      | `0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168` | 6        | Global Dollar (Paxos), ~ $1.00 |
+| syrupUSDG | `0x40858070814a57FdF33a613ae84fE0a8b4a874f7` | 6        | Maple yield-bearing, **> $1**  |
+
+### The starting price is the one thing you must get right
+
+syrupUSDG is **yield-bearing**, so 1 syrupUSDG is worth **more** than 1 USDG, and that ratio drifts
+upward over time as yield accrues. The pool's starting price must match the current redemption ratio,
+or the pool gets arbitraged the moment it is live.
+
+The syrupUSDG deployed on Robinhood is a **bridged ERC-20**: it has no onchain exchange-rate function
+(`convertToAssets`, `previewRedeem`, etc. all revert), so the ratio cannot be read from the RH contract.
+**Get the current syrupUSDG → USDG rate from Maple** (or from the canonical syrupUSDG vault on its home
+chain) at run time. Then:
+
+- `PRICE_A_USD_8DP` for USDG = `100000000` ($1.00)
+- `PRICE_B_USD_8DP` for syrupUSDG = `rate × 1e8`. Example: if 1 syrupUSDG = 1.05 USDG, use `105000000`.
+
+Only the **ratio** between the two prices matters, so you can also express it relative to $1: USDG at
+`100000000` and syrupUSDG at the rate × 1e8.
+
+### Yield drift caveat (worth telling Maple)
+
+Because the pool price is set once and only moves via swaps, a full-range syrupUSDG/USDG pool slowly
+becomes underpriced as syrupUSDG accrues yield: the real NAV rises but the pool price does not, so
+arbitrageurs buy syrupUSDG cheap from the pool and LPs bleed the yield over time. For a modest test/
+bootstrap pool this is small in absolute terms, but it is inherent to LPing a yield-bearing token
+against its underlying in a constant-product AMM. Keep the size modest, monitor it, and re-seed or
+re-price if it drifts materially.
+
+---
+
+## You never touch ticks or sqrt prices
+
+You only ever provide USD prices and a USD budget. The script converts those into the v4
+`sqrtPriceX96`, the tick range, and the liquidity. Use a live quote for the prices on the first run,
+since that run sets the pool's starting price.
+
+This script supports **equal-decimal** pairs only (e.g. two 6-decimal stables, or two 18-decimal
+tokens). The USD→amount math assumes both tokens share decimals.
+
+---
+
+## Step 0: confirm tokens and gas (do this first)
+
+Never hardcode token addresses. Confirm the canonical addresses from the issuer's docs, then verify
+onchain:
+
+```bash
+export RH_RPC=<your-robinhood-rpc>          # read+write endpoint for broadcast; Blockscout RPC ok for reads
+export USDG=0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168
+export SYRUP_USDG=0x40858070814a57FdF33a613ae84fE0a8b4a874f7
+cast call $USDG       "symbol()(string)"  --rpc-url $RH_RPC   # USDG
+cast call $USDG       "decimals()(uint8)" --rpc-url $RH_RPC   # 6
+cast call $SYRUP_USDG "symbol()(string)"  --rpc-url $RH_RPC   # syrupUSDG
+cast call $SYRUP_USDG "decimals()(uint8)" --rpc-url $RH_RPC   # 6 (matches USDG)
+```
+
+Make sure your deploy EOA holds:
+- a little **ETH** for gas, and
+- enough of **each token** to cover the per-side budget you choose.
+
+Prefer a dedicated seeding EOA over a treasury wallet: the script grants standing Permit2 allowances
+from whichever account runs it.
+
+---
+
+## Inputs (all USD figures scaled by 1e8, "Chainlink style")
+
+| Env var            | Meaning                                  | Example                              |
+|--------------------|------------------------------------------|--------------------------------------|
+| `TOKEN_A`          | one token address (order doesn't matter) | `0x...`                              |
+| `TOKEN_B`          | the other token address                  | `0x...`                              |
+| `PRICE_A_USD_8DP`  | USD price of 1 whole TOKEN_A × 1e8       | $1.00 → `100000000`                  |
+| `PRICE_B_USD_8DP`  | USD price of 1 whole TOKEN_B × 1e8       | $1.08 → `108000000`                  |
+| `USD_PER_SIDE_8DP` | USD value to deposit per side × 1e8      | $2 test → `200000000`; $1000 → `100000000000` |
+
+Rule for the 1e8 scale: multiply the dollar figure by `100000000`. Use a live quote for any non-$1
+price at run time.
+
+The script also needs two env vars so `foundry.toml` parses (they are never used here):
+
+```bash
+export TENDERLY_PUBLIC_RPC_URL=http://x
+export TENDERLY_ACCESS_KEY=dummy
+```
+
+---
+
+## Run 1: tiny test seed (this sets the starting price)
+
+```bash
+export TOKEN_A=$USDG                   # 0x5fc5...d168
+export TOKEN_B=$SYRUP_USDG             # 0x4085...74f7
+export PRICE_A_USD_8DP=100000000      # USDG $1.00
+export PRICE_B_USD_8DP=105000000      # syrupUSDG: rate x 1e8  <-- replace 1.05 with the live Maple rate
+export USD_PER_SIDE_8DP=200000000     # $2 per side for the test
+
+# Dry run first (no broadcast). Read the logged amounts/price and confirm they look right.
+# Works against the read-only Blockscout RPC.
+forge script script/smoke/SeedStablePoolV4.s.sol \
+  --rpc-url $RH_RPC --sender <YOUR_EOA> --skip '*/node_modules/*'
+
+# Broadcast (needs the read+write RPC):
+forge script script/smoke/SeedStablePoolV4.s.sol \
+  --rpc-url $RH_RPC --account <keystore-name> --sender <YOUR_EOA> \
+  --broadcast --slow --legacy --with-gas-price 200000000 --gas-estimate-multiplier 400 \
+  --skip '*/node_modules/*'
+```
+
+Why these flags on Robinhood (an Orbit chain):
+- `--slow`: submit nonces sequentially; avoids reordering on sequencer-driven chains.
+- `--legacy`: Robinhood's RPC path is happiest with legacy gas pricing.
+- `--with-gas-price 200000000`: 0.2 gwei; this is the **actual broadcast price** (not `--gas-price`,
+  which only affects simulation).
+- `--gas-estimate-multiplier 400`: the small approval txs otherwise get rejected as
+  `intrinsic gas too low` because forge's local sizing doesn't model Orbit's L1-data gas. Excess gas is
+  rebated, so over-budgeting is free.
+
+---
+
+## Test it (read-only quote, does not move the price)
+
+For this pair, sorted by address: `c0 = syrupUSDG` (`0x4085...74f7`), `c1 = USDG` (`0x5fc5...d168`).
+`zeroForOne=true` sells `c0` (syrupUSDG). The amount `1000000` is 1 token (6 decimals).
+
+```bash
+cast call 0x8dc178efb8111bb0973dd9d722ebeff267c98f94 \
+  "quoteExactInputSingle(((address,address,uint24,int24,address),bool,uint128,bytes))(uint256,uint256)" \
+  "(($SYRUP_USDG,$USDG,500,10,0x0000000000000000000000000000000000000000),true,1000000,0x)" \
+  --rpc-url $RH_RPC
+```
+
+It returns `(amountOut, gasEstimate)` and simulates the swap without changing the pool price. That
+matters because when you top up, the new liquidity is added at the pool's current price, so you want
+the price still sitting where you created it. A real swap would shift it; the quote does not.
+
+**Expect the quoted rate to look bad at this stage.** Quoting 1 whole token against only a few dollars
+of seeded depth has heavy price impact, so `amountOut` will come back noticeably below the FX rate.
+That is depth, not mispricing. Check that the direction and rough ratio make sense (or quote a much
+smaller amount); the rate tightens up once the full liquidity is in.
+
+---
+
+## Run 2: top up to full size (price unchanged)
+
+Re-run the exact same command with the real budget. The script detects the pool is already initialized,
+reads the live price from StateView, and adds liquidity there without re-pricing.
+
+Two things about this run:
+
+- **Re-export every env var, not just the budget** (fresh shells lose them, and the script needs the
+  prices to size the amounts). Refresh `PRICE_B_USD_8DP` from a live FX quote at the same time.
+- **A leftover on one side is normal.** The prices size the two amounts, but the pool's live price
+  decides the exact ratio it accepts; the script deposits the binding side in full and up to the
+  requested amount of the other. Whatever isn't consumed stays in your wallet, nothing is lost.
+
+```bash
+export TOKEN_A=$USDG
+export TOKEN_B=$SYRUP_USDG
+export PRICE_A_USD_8DP=100000000       # USDG $1.00
+export PRICE_B_USD_8DP=105000000       # refresh with the live Maple rate
+export USD_PER_SIDE_8DP=100000000000   # $1000 per side
+forge script script/smoke/SeedStablePoolV4.s.sol \
+  --rpc-url $RH_RPC --account <keystore-name> --sender <YOUR_EOA> \
+  --broadcast --slow --legacy --with-gas-price 200000000 --gas-estimate-multiplier 400 \
+  --skip '*/node_modules/*'
+```
+
+---
+
+## What the script does (and its safety checks)
+
+- Resolves all infra addresses from `deployments/json/4663.json` (nothing hardcoded).
+- Sorts the tokens (`currency0 < currency1`) and keeps prices/amounts aligned.
+- Requires equal decimals (the USD→price math assumes it).
+- First run: computes `sqrtPriceX96` from the USD prices and initializes. Later runs: funds at the live
+  price read from StateView.
+- Derives token amounts from `USD_PER_SIDE_8DP` and the prices, and the liquidity from those amounts.
+- Uses the 0.05% fee tier and a full-range position.
+- Permit2 dual-approval, then `modifyLiquidities` (`MINT_POSITION` + `SETTLE_PAIR`).
+- Checks your token balances before minting, and asserts pool liquidity increased afterward.
+
+## Fee tier
+
+This script uses the v4 0.05% fee tier with tick spacing 10 (`FEE = 500`, `TICK_SPACING = 10`). In v4 any
+fee/tickSpacing combo is allowed; edit the constants at the top of the script if you want a different
+tier.
+
+---
+
+## Validation status
+
+This script + flow was run end-to-end against a fork of a live Robinhood (4663) node, exercising the
+real PoolManager / PositionManager / StateView at the addresses above:
+
+- Run 1 (init + seed): pool initialized at the USD-derived price, position minted, liquidity 0 → nonzero.
+- Run 2 (top-up): detected already-initialized, added liquidity at the live price with the price
+  unchanged.
+- V4Quoter read-only quote: routed and returned an amount-out + gas estimate.
+
+Specifically for **syrupUSDG / USDG**, a fork test using the **real token contracts** confirmed:
+
+- both tokens are freely transferable into the PositionManager (no whitelist / transfer restriction),
+- the 6-decimal equal-decimals path works,
+- a 1.05 syrupUSDG/USDG rate initialized at the correct tick (≈ `1.0001^487 = 1.05`) and minted
+  liquidity successfully.
+
+The mint encoding matches the v4 smoke test that already passes on chain 4663.
+
+## References
+
+- Script: `script/smoke/SeedStablePoolV4.s.sol`
+- Proven-on-4663 v4 flow: `script/smoke/V4SmokeTest.s.sol`
+- Uniswap v4 docs: https://docs.uniswap.org/contracts/v4/overview

--- a/script/smoke/SeedStablePoolV4.s.sol
+++ b/script/smoke/SeedStablePoolV4.s.sol
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT
+// ^0.8.20 to match the sibling smoke scripts in this directory (these are not deployed).
+pragma solidity ^0.8.20;
+
+import {Script, console2 as console} from 'forge-std/Script.sol';
+
+// Real v4 math libraries (briefcase copies are self-contained, pragma ^0.8.0).
+import {FullMath} from '../../src/briefcase/protocols/v4-core/libraries/FullMath.sol';
+import {TickMath} from '../../src/briefcase/protocols/v4-core/libraries/TickMath.sol';
+import {LiquidityAmounts} from '../../src/briefcase/protocols/v4-periphery/libraries/LiquidityAmounts.sol';
+
+interface IERC20Min {
+    function approve(address spender, uint256 amount) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function balanceOf(address) external view returns (uint256);
+    function symbol() external view returns (string memory);
+    function decimals() external view returns (uint8);
+}
+
+interface IPermit2 {
+    function approve(address token, address spender, uint160 amount, uint48 expiration) external;
+    function allowance(address user, address token, address spender)
+        external
+        view
+        returns (uint160 amount, uint48 expiration, uint48 nonce);
+}
+
+// Mirrors PoolKey from v4-core
+struct PoolKey {
+    address currency0;
+    address currency1;
+    uint24 fee;
+    int24 tickSpacing;
+    address hooks;
+}
+
+interface IPositionManager {
+    function initializePool(PoolKey calldata key, uint160 sqrtPriceX96) external returns (int24);
+    function modifyLiquidities(bytes calldata unlockData, uint256 deadline) external payable;
+    function nextTokenId() external view returns (uint256);
+}
+
+interface IStateView {
+    function getSlot0(bytes32 poolId)
+        external
+        view
+        returns (uint160 sqrtPriceX96, int24 tick, uint24 protocolFee, uint24 lpFee);
+    function getLiquidity(bytes32 poolId) external view returns (uint128 liquidity);
+}
+
+/// @notice Creates AND funds a Uniswap v4 pool for an equal-decimals stable pair (e.g. USDC/EURC).
+///
+/// @dev USD-NATIVE INTERFACE. The operator only ever supplies plain USD figures. They never compute a
+///      tick or a sqrtPriceX96. This script derives both from the USD prices.
+///
+///      Env vars (all USD figures are scaled by 1e8, "Chainlink style": $1.00 = 100000000):
+///        TOKEN_A, TOKEN_B            token addresses (order does not matter; sorted internally)
+///        PRICE_A_USD_8DP            USD price of 1 whole TOKEN_A, x1e8   (e.g. USDC $1.00 -> 100000000)
+///        PRICE_B_USD_8DP            USD price of 1 whole TOKEN_B, x1e8   (e.g. EURC $1.08 -> 108000000)
+///        USD_PER_SIDE_8DP           target USD value to deposit on EACH side, x1e8 ($1000 -> 100000000000)
+///
+///      STAGED FUNDING (run this script more than once):
+///        - 1st run sets the pool's STARTING price from the USD prices. Initialization happens once per
+///          pool (you cannot re-initialize), but the price floats with swaps afterward like any AMM.
+///          Use a real FX quote and start with a SMALL USD_PER_SIDE: if the starting price is off, the
+///          pool gets arbitraged and the loss scales with the liquidity posted, so keep the first run tiny.
+///        - After confirming a test swap routes, run again with the full USD_PER_SIDE. The pool is already
+///          initialized, so this run skips init and adds liquidity at the pool's CURRENT live price
+///          (read from StateView), whatever swaps have left it at.
+contract SeedStablePoolV4 is Script {
+    // v4 Action codes
+    uint8 constant MINT_POSITION = 0x02;
+    uint8 constant SETTLE_PAIR = 0x0d;
+
+    // Sensible stable-pair params. In v4 ANY fee/tickSpacing combo is allowed (no externally-enabled tiers).
+    uint24 constant FEE = 500; // 0.05%
+    int24 constant TICK_SPACING = 10;
+
+    uint256 constant USD_SCALE = 1e8; // all *_8DP env inputs use this scale
+
+    struct Env {
+        address permit2;
+        address poolManager;
+        address positionManager;
+        address stateView;
+    }
+
+    function run() public {
+        Env memory e = _loadEnv();
+
+        // --- Inputs (never hardcoded) ---
+        address tokenA = vm.envAddress('TOKEN_A');
+        address tokenB = vm.envAddress('TOKEN_B');
+        uint256 priceA8 = vm.envUint('PRICE_A_USD_8DP');
+        uint256 priceB8 = vm.envUint('PRICE_B_USD_8DP');
+        uint256 usdPerSide8 = vm.envUint('USD_PER_SIDE_8DP');
+
+        require(tokenA != address(0) && tokenB != address(0), 'token addr zero');
+        require(tokenA != tokenB, 'tokens identical');
+        require(priceA8 > 0 && priceB8 > 0, 'price zero');
+        require(usdPerSide8 > 0, 'budget zero');
+
+        // Order by address: currency0 < currency1. Reorder prices to match.
+        (address c0, address c1, uint256 price0_8, uint256 price1_8) =
+            tokenA < tokenB ? (tokenA, tokenB, priceA8, priceB8) : (tokenB, tokenA, priceB8, priceA8);
+
+        // The 1:1-cancellation in the price/amount math below is only valid when both tokens share decimals.
+        uint8 dec0 = IERC20Min(c0).decimals();
+        uint8 dec1 = IERC20Min(c1).decimals();
+        require(dec0 == dec1, 'unequal decimals: this script supports equal-decimal stable pairs only');
+
+        // Convert the USD budget into raw token amounts: amount_raw = usdPerSide / price * 10^decimals.
+        uint256 unit = 10 ** uint256(dec0);
+        uint256 amount0 = FullMath.mulDiv(usdPerSide8, unit, price0_8);
+        uint256 amount1 = FullMath.mulDiv(usdPerSide8, unit, price1_8);
+        require(amount0 > 0 && amount1 > 0, 'computed amount is zero (budget too small)');
+
+        PoolKey memory key =
+            PoolKey({currency0: c0, currency1: c1, fee: FEE, tickSpacing: TICK_SPACING, hooks: address(0)});
+        bytes32 poolId = keccak256(abi.encode(key));
+
+        // If the pool is already initialized, fund at its LIVE price (top-up run); otherwise compute the
+        // initialization price from the USD prices (first run).
+        (uint160 livePrice,,,) = IStateView(e.stateView).getSlot0(poolId);
+        bool alreadyInitialized = livePrice != 0;
+        uint160 sqrtPriceX96 = alreadyInitialized ? livePrice : _sqrtPriceFromUsd(price0_8, price1_8);
+
+        // Full-range ticks aligned to tickSpacing.
+        int24 tickLower = TickMath.minUsableTick(TICK_SPACING);
+        int24 tickUpper = TickMath.maxUsableTick(TICK_SPACING);
+        uint160 sqrtLower = TickMath.getSqrtPriceAtTick(tickLower);
+        uint160 sqrtUpper = TickMath.getSqrtPriceAtTick(tickUpper);
+
+        // Derive the liquidity that the desired amounts buy at the (live or target) price. For a full-range
+        // position straddling the price, this is the binding minimum of the liquidity implied by each side,
+        // so the deposit consumes the requested amount of the binding side and <= requested of the other.
+        uint128 liquidity =
+            LiquidityAmounts.getLiquidityForAmounts(sqrtPriceX96, sqrtLower, sqrtUpper, amount0, amount1);
+        require(liquidity > 0, 'computed liquidity is zero');
+
+        vm.startBroadcast();
+        address me = msg.sender;
+
+        _logSetup(e, key, c0, c1, amount0, amount1, liquidity, sqrtPriceX96, alreadyInitialized, me);
+
+        require(IERC20Min(c0).balanceOf(me) >= amount0, 'insufficient currency0 balance');
+        require(IERC20Min(c1).balanceOf(me) >= amount1, 'insufficient currency1 balance');
+
+        if (!alreadyInitialized) {
+            IPositionManager(e.positionManager).initializePool(key, sqrtPriceX96);
+            console.log('Pool initialized at the USD-derived starting price (init happens once per pool).');
+        } else {
+            console.log('Pool already initialized; topping up at the live price (price unchanged).');
+        }
+
+        _approvePermit2(c0, c1, e, me);
+
+        uint128 liqBefore = IStateView(e.stateView).getLiquidity(poolId);
+        uint256 tokenId = IPositionManager(e.positionManager).nextTokenId();
+
+        // amount maxes: requested amount + 1% headroom. The liquidity was derived as the binding minimum of
+        // the two sides, so the pool can never need more than `amount` plus round-up dust at the quoted
+        // price; the 1% buffer absorbs that rounding plus small price movement between simulation and
+        // inclusion. If the price is shoved further than 1% mid-flight, the mint reverts instead of
+        // depositing at the manipulated price.
+        uint128 amount0Max = _withBuffer(amount0);
+        uint128 amount1Max = _withBuffer(amount1);
+        bytes memory actions = abi.encodePacked(MINT_POSITION, SETTLE_PAIR);
+        bytes[] memory params = new bytes[](2);
+        params[0] = abi.encode(key, tickLower, tickUpper, uint256(liquidity), amount0Max, amount1Max, me, bytes(''));
+        params[1] = abi.encode(key.currency0, key.currency1);
+
+        IPositionManager(e.positionManager).modifyLiquidities(abi.encode(actions, params), block.timestamp + 3600);
+        console.log('Minted v4 position tokenId:', tokenId);
+
+        _verifyPool(e.stateView, poolId, tokenId, liqBefore);
+
+        console.log('');
+        console.log('SUCCESS: v4 stable pool created/topped up with full-range liquidity');
+        vm.stopBroadcast();
+    }
+
+    /// @notice sqrtPriceX96 for an equal-decimals pair from USD prices. price(token1/token0) = price0/price1.
+    function _sqrtPriceFromUsd(uint256 price0_8, uint256 price1_8) internal pure returns (uint160) {
+        // inner = (price0/price1) * 2^192  ->  sqrt(inner) = sqrt(price) * 2^96 = sqrtPriceX96
+        uint256 inner = FullMath.mulDiv(price0_8, uint256(1) << 192, price1_8);
+        uint256 sp = _sqrt(inner);
+        require(sp > TickMath.MIN_SQRT_PRICE && sp < TickMath.MAX_SQRT_PRICE, 'price out of range');
+        return uint160(sp);
+    }
+
+    /// @notice Floor integer square root (Babylonian method).
+    function _sqrt(uint256 x) internal pure returns (uint256) {
+        if (x == 0) return 0;
+        uint256 z = (x + 1) / 2;
+        uint256 y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
+        return y;
+    }
+
+    function _loadEnv() internal view returns (Env memory e) {
+        string memory path = string.concat('./deployments/json/', vm.toString(block.chainid), '.json');
+        string memory json = vm.readFile(path);
+
+        e.permit2 = vm.parseJsonAddress(json, '.latest.Permit2.address');
+        e.poolManager = vm.parseJsonAddress(json, '.latest.PoolManager.address');
+        e.positionManager = vm.parseJsonAddress(json, '.latest.PositionManager.address');
+        e.stateView = vm.parseJsonAddress(json, '.latest.StateView.address');
+
+        require(e.permit2 != address(0), 'Permit2 not in deployments JSON');
+        require(e.poolManager != address(0), 'PoolManager not in deployments JSON');
+        require(e.positionManager != address(0), 'PositionManager not in deployments JSON');
+        require(e.stateView != address(0), 'StateView not in deployments JSON');
+    }
+
+    /// @notice Requested amount plus 1% headroom, saturating at uint128.max.
+    function _withBuffer(uint256 amount) internal pure returns (uint128) {
+        uint256 buffered = amount + amount / 100 + 1;
+        return buffered > type(uint128).max ? type(uint128).max : uint128(buffered);
+    }
+
+    function _approvePermit2(address c0, address c1, Env memory e, address me) internal {
+        // Only issue approvals that are actually missing, so re-runs (top-ups) don't emit redundant
+        // infinite-approval transactions.
+        // Step 1: let Permit2 pull tokens from msg.sender.
+        if (IERC20Min(c0).allowance(me, e.permit2) != type(uint256).max) {
+            IERC20Min(c0).approve(e.permit2, type(uint256).max);
+        }
+        if (IERC20Min(c1).allowance(me, e.permit2) != type(uint256).max) {
+            IERC20Min(c1).approve(e.permit2, type(uint256).max);
+        }
+        // Step 2: give PositionManager spender allowance via Permit2.
+        (uint160 amt0, uint48 exp0,) = IPermit2(e.permit2).allowance(me, c0, e.positionManager);
+        if (amt0 != type(uint160).max || exp0 != type(uint48).max) {
+            IPermit2(e.permit2).approve(c0, e.positionManager, type(uint160).max, type(uint48).max);
+        }
+        (uint160 amt1, uint48 exp1,) = IPermit2(e.permit2).allowance(me, c1, e.positionManager);
+        if (amt1 != type(uint160).max || exp1 != type(uint48).max) {
+            IPermit2(e.permit2).approve(c1, e.positionManager, type(uint160).max, type(uint48).max);
+        }
+        console.log('Permit2 allowances in place for PositionManager (skipped any already granted)');
+    }
+
+    function _logSetup(
+        Env memory e,
+        PoolKey memory key,
+        address c0,
+        address c1,
+        uint256 amount0,
+        uint256 amount1,
+        uint128 liquidity,
+        uint160 sqrtPriceX96,
+        bool alreadyInitialized,
+        address me
+    ) internal view {
+        console.log('Chain:', block.chainid);
+        console.log('Sender:', me);
+        console.log('PoolManager:', e.poolManager);
+        console.log('PositionManager:', e.positionManager);
+        console.log('StateView:', e.stateView);
+        console.log('Permit2:', e.permit2);
+        console.log('pool already initialized:', alreadyInitialized);
+        console.log('currency0:', c0);
+        console.log('  symbol:', IERC20Min(c0).symbol());
+        console.log('  amount0 to deposit (raw):', amount0);
+        console.log('currency1:', c1);
+        console.log('  symbol:', IERC20Min(c1).symbol());
+        console.log('  amount1 to deposit (raw):', amount1);
+        console.log('fee:', key.fee);
+        console.log('sqrtPriceX96 (computed, no operator input):', sqrtPriceX96);
+        console.log('computed liquidity:', liquidity);
+    }
+
+    function _verifyPool(address stateView, bytes32 poolId, uint256 tokenId, uint128 liqBefore) internal view {
+        (uint160 sqrtPriceX96, int24 tick,,) = IStateView(stateView).getSlot0(poolId);
+        uint128 liqAfter = IStateView(stateView).getLiquidity(poolId);
+        console.log('Pool id:');
+        console.logBytes32(poolId);
+        console.log('Pool slot0 sqrtPriceX96:', sqrtPriceX96);
+        console.log('Pool tick:', tick);
+        console.log('pool liquidity before:', liqBefore);
+        console.log('pool liquidity after:', liqAfter);
+        require(liqAfter > liqBefore, 'liquidity did not increase');
+        require(tokenId > 0, 'no position minted');
+    }
+}


### PR DESCRIPTION
Commits the pool-seeding tooling that until now only lived out-of-band (used for the Robinhood syrupUSDG/USDG and Arc EURC/USDC pool bootstraps), with some hardening on top.

**Scripts** (`script/smoke/`):
- `SeedStablePoolV4.s.sol`: USD-native interface for equal-decimals stable pairs; operator supplies USD prices + budget, script derives sqrtPrice/range/liquidity. Full-range.
- `SeedPoolV4.s.sol`: amount-native interface, any decimals; starting price = deposit ratio. Concentrated position (default ±100 ticks).

Both are chain-agnostic (resolve infra from `deployments/json/<chainid>.json`) and staged-funding aware: first run initializes, later runs top up at the live price.

**Hardening vs the versions already used in production:**
- Mint slippage caps: `amount0Max/amount1Max` are now requested amount +1% instead of `type(uint128).max`. If the pool price is moved between simulation and inclusion, the mint reverts instead of depositing at the manipulated price.
- Approval skip: token→Permit2 and Permit2→PositionManager approvals are only sent when missing, so top-up runs don't re-emit infinite approvals.

**Guide updates:** expected price impact on the tiny-seed quote test (depth, not mispricing), re-export env vars + refresh the FX quote before the top-up run, leftover-on-one-side is normal, prefer a dedicated seeding EOA, and the "script does not sanity-check your ratio" warning moved up to the pricing section.

**Testing:** fork test on Ink (57073) against the live PoolManager/PositionManager/StateView ran both scripts through init + top-up: correct init tick for a 1.166 price ratio, top-up at unchanged live price, approvals skipped on second run, slippage caps non-binding on the honest path. The stable script (pre-hardening) also has live production history: Arc 5042 EURC/USDC (2026-08-04) and the earlier Robinhood 4663 validation documented in the guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)